### PR TITLE
Ember-Cli 0.2.2, also fixed Node-Sass Version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,14 +2,14 @@
   "name": "azureexplorer",
   "dependencies": {
     "jquery": "^2.1.1",
-    "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.16",
-    "ember-resolver": "~0.1.14",
+    "ember": "1.11.0",
+    "ember-data": "1.0.0-beta.16.1",
+    "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.2.8",
+    "ember-qunit": "0.3.0",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1",
     "materialize": "~0.95.0"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,11566 @@
+{
+  "name": "azureexplorer",
+  "version": "0.0.0",
+  "dependencies": {
+    "azure-storage": {
+      "version": "0.4.3",
+      "from": "azure-storage@>=0.4.3 <0.5.0",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-0.4.3.tgz",
+      "dependencies": {
+        "xml2js": {
+          "version": "0.2.7",
+          "from": "xml2js@0.2.7",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.7.tgz",
+          "dependencies": {
+            "sax": {
+              "version": "0.5.2",
+              "from": "sax@0.5.2",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.2.tgz"
+            }
+          }
+        },
+        "xmlbuilder": {
+          "version": "0.4.3",
+          "from": "xmlbuilder@0.4.3",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz"
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "from": "underscore@>=1.4.4 <1.5.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+        },
+        "request": {
+          "version": "2.27.0",
+          "from": "request@>=2.27.0 <2.28.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.27.0.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.6.6",
+              "from": "qs@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.3.0",
+              "from": "tunnel-agent@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "hawk": {
+              "version": "1.0.0",
+              "from": "hawk@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign": {
+              "version": "0.3.0",
+              "from": "aws-sign@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.3.0",
+              "from": "oauth-sign@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+            },
+            "cookie-jar": {
+              "version": "0.3.0",
+              "from": "cookie-jar@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "validator": {
+          "version": "3.1.0",
+          "from": "validator@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-3.1.0.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@>=1.2.4 <1.3.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "node-uuid": {
+          "version": "1.4.3",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+        },
+        "extend": {
+          "version": "1.2.1",
+          "from": "extend@>=1.2.1 <1.3.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.33",
+          "from": "readable-stream@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "broccoli-asset-rev": {
+      "version": "2.0.2",
+      "from": "broccoli-asset-rev@2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-asset-rev/-/broccoli-asset-rev-2.0.2.tgz",
+      "dependencies": {
+        "broccoli-asset-rewrite": {
+          "version": "1.0.4",
+          "from": "broccoli-asset-rewrite@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-asset-rewrite/-/broccoli-asset-rewrite-1.0.4.tgz"
+        },
+        "broccoli-filter": {
+          "version": "0.1.12",
+          "from": "broccoli-filter@>=0.1.6 <0.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.12.tgz",
+          "dependencies": {
+            "quick-temp": {
+              "version": "0.1.2",
+              "from": "quick-temp@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.6 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "mktemp@>=0.3.4 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@>=2.3.3 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "broccoli-writer": {
+              "version": "0.1.1",
+              "from": "broccoli-writer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz"
+            },
+            "walk-sync": {
+              "version": "0.1.3",
+              "from": "walk-sync@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+            },
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.6",
+              "from": "broccoli-kitchen-sink-helpers@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.0.4",
+                  "from": "glob@4.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "promise-map-series": {
+              "version": "0.2.1",
+              "from": "promise-map-series@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.1.tgz"
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.0.18",
+          "from": "rsvp@>=3.0.6 <3.1.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+        }
+      }
+    },
+    "ember-cli": {
+      "version": "0.2.2",
+      "from": "ember-cli@0.2.2",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-0.2.2.tgz",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.5",
+          "from": "abbrev@>=1.0.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+        },
+        "bower": {
+          "version": "1.3.12",
+          "from": "bower@>=1.3.12 <2.0.0",
+          "resolved": "https://registry.npmjs.org/bower/-/bower-1.3.12.tgz",
+          "dependencies": {
+            "archy": {
+              "version": "0.0.2",
+              "from": "archy@0.0.2",
+              "resolved": "https://registry.npmjs.org/archy/-/archy-0.0.2.tgz"
+            },
+            "bower-endpoint-parser": {
+              "version": "0.2.2",
+              "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+            },
+            "bower-json": {
+              "version": "0.4.0",
+              "from": "bower-json@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.2.11",
+                  "from": "deep-extend@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "intersect": {
+                  "version": "0.0.3",
+                  "from": "intersect@>=0.0.3 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+                }
+              }
+            },
+            "bower-logger": {
+              "version": "0.2.2",
+              "from": "bower-logger@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+            },
+            "bower-registry-client": {
+              "version": "0.2.4",
+              "from": "bower-registry-client@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.2.4.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.8 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "lru-cache": {
+                  "version": "2.3.1",
+                  "from": "lru-cache@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+                },
+                "request": {
+                  "version": "2.51.0",
+                  "from": "request@>=2.51.0 <2.52.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "from": "bl@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.8.0",
+                      "from": "caseless@>=0.8.0 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.2.0",
+                      "from": "form-data@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.0",
+                          "from": "async@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.0.10",
+                          "from": "mime-types@>=2.0.3 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.8.0",
+                              "from": "mime-db@>=1.8.0 <1.9.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "qs": {
+                      "version": "2.3.3",
+                      "from": "qs@>=2.3.1 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.3.2",
+                          "from": "punycode@>=0.2.0",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.5.0",
+                      "from": "oauth-sign@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "from": "hawk@1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "request-replay": {
+                  "version": "0.2.0",
+                  "from": "request-replay@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                }
+              }
+            },
+            "cardinal": {
+              "version": "0.4.0",
+              "from": "cardinal@0.4.0",
+              "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.0.tgz",
+              "dependencies": {
+                "redeyed": {
+                  "version": "0.4.4",
+                  "from": "redeyed@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.4 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "0.5.0",
+              "from": "chalk@0.5.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                }
+              }
+            },
+            "chmodr": {
+              "version": "0.1.0",
+              "from": "chmodr@0.1.0",
+              "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+            },
+            "decompress-zip": {
+              "version": "0.0.8",
+              "from": "decompress-zip@0.0.8",
+              "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
+              "dependencies": {
+                "mkpath": {
+                  "version": "0.1.0",
+                  "from": "mkpath@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+                },
+                "binary": {
+                  "version": "0.3.0",
+                  "from": "binary@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+                  "dependencies": {
+                    "chainsaw": {
+                      "version": "0.1.0",
+                      "from": "chainsaw@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                      "dependencies": {
+                        "traverse": {
+                          "version": "0.3.9",
+                          "from": "traverse@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                        }
+                      }
+                    },
+                    "buffers": {
+                      "version": "0.1.1",
+                      "from": "buffers@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                    }
+                  }
+                },
+                "touch": {
+                  "version": "0.0.2",
+                  "from": "touch@0.0.2",
+                  "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+                  "dependencies": {
+                    "nopt": {
+                      "version": "1.0.10",
+                      "from": "nopt@>=1.0.10 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "2.2.1",
+                  "from": "nopt@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz"
+                }
+              }
+            },
+            "fstream": {
+              "version": "1.0.4",
+              "from": "fstream@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.4.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.2",
+              "from": "fstream-ignore@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "4.0.6",
+              "from": "glob@>=4.0.2 <4.1.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "graceful-fs@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "handlebars": {
+              "version": "2.0.0",
+              "from": "handlebars@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "inquirer": {
+              "version": "0.7.1",
+              "from": "inquirer@0.7.1",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.7.1.tgz",
+              "dependencies": {
+                "cli-color": {
+                  "version": "0.3.3",
+                  "from": "cli-color@>=0.3.2 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.6",
+                      "from": "es5-ext@>=0.10.6 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "memoizee": {
+                      "version": "0.3.8",
+                      "from": "memoizee@>=0.3.8 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                      "dependencies": {
+                        "es6-weak-map": {
+                          "version": "0.1.2",
+                          "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "from": "es6-iterator@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                              "dependencies": {
+                                "es6-symbol": {
+                                  "version": "2.0.1",
+                                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "es6-symbol": {
+                              "version": "0.1.1",
+                              "from": "es6-symbol@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "event-emitter": {
+                          "version": "0.3.3",
+                          "from": "event-emitter@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                        },
+                        "lru-queue": {
+                          "version": "0.1.0",
+                          "from": "lru-queue@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                        },
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                        }
+                      }
+                    },
+                    "timers-ext": {
+                      "version": "0.1.0",
+                      "from": "timers-ext@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                      "dependencies": {
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "from": "next-tick@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "figures": {
+                  "version": "1.3.5",
+                  "from": "figures@>=1.3.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+                },
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                },
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "rx": {
+                  "version": "2.4.7",
+                  "from": "rx@>=2.2.27 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.7.tgz"
+                }
+              }
+            },
+            "insight": {
+              "version": "0.4.3",
+              "from": "insight@0.4.3",
+              "resolved": "https://registry.npmjs.org/insight/-/insight-0.4.3.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                },
+                "chalk": {
+                  "version": "0.5.1",
+                  "from": "chalk@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "inquirer": {
+                  "version": "0.6.0",
+                  "from": "inquirer@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.6.0.tgz",
+                  "dependencies": {
+                    "cli-color": {
+                      "version": "0.3.3",
+                      "from": "cli-color@>=0.3.2 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "from": "d@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.6",
+                          "from": "es5-ext@>=0.10.6 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "from": "es6-iterator@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                            },
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "memoizee": {
+                          "version": "0.3.8",
+                          "from": "memoizee@>=0.3.8 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                          "dependencies": {
+                            "es6-weak-map": {
+                              "version": "0.1.2",
+                              "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                              "dependencies": {
+                                "es6-iterator": {
+                                  "version": "0.1.3",
+                                  "from": "es6-iterator@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                                  "dependencies": {
+                                    "es6-symbol": {
+                                      "version": "2.0.1",
+                                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "es6-symbol": {
+                                  "version": "0.1.1",
+                                  "from": "es6-symbol@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                                }
+                              }
+                            },
+                            "event-emitter": {
+                              "version": "0.3.3",
+                              "from": "event-emitter@>=0.3.1 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                            },
+                            "lru-queue": {
+                              "version": "0.1.0",
+                              "from": "lru-queue@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                            },
+                            "next-tick": {
+                              "version": "0.2.2",
+                              "from": "next-tick@>=0.2.2 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                            }
+                          }
+                        },
+                        "timers-ext": {
+                          "version": "0.1.0",
+                          "from": "timers-ext@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                          "dependencies": {
+                            "next-tick": {
+                              "version": "0.2.2",
+                              "from": "next-tick@>=0.2.2 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "2.4.1",
+                      "from": "lodash@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                    },
+                    "mute-stream": {
+                      "version": "0.0.4",
+                      "from": "mute-stream@0.0.4",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                    },
+                    "rx": {
+                      "version": "2.4.7",
+                      "from": "rx@>=2.2.27 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/rx/-/rx-2.4.7.tgz"
+                    }
+                  }
+                },
+                "lodash.debounce": {
+                  "version": "2.4.1",
+                  "from": "lodash.debounce@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.isfunction": {
+                      "version": "2.4.1",
+                      "from": "lodash.isfunction@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.now": {
+                      "version": "2.4.1",
+                      "from": "lodash.now@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.now/-/lodash.now-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "1.0.0",
+                  "from": "object-assign@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
+                },
+                "os-name": {
+                  "version": "1.0.3",
+                  "from": "os-name@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+                  "dependencies": {
+                    "osx-release": {
+                      "version": "1.0.0",
+                      "from": "osx-release@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.1.1",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "win-release": {
+                      "version": "1.0.0",
+                      "from": "win-release@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
+                    }
+                  }
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.1 <0.13.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-root": {
+              "version": "1.0.0",
+              "from": "is-root@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+            },
+            "junk": {
+              "version": "1.0.1",
+              "from": "junk@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
+            },
+            "lockfile": {
+              "version": "1.0.0",
+              "from": "lockfile@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
+            },
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@>=2.5.0 <2.6.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "opn": {
+              "version": "1.0.1",
+              "from": "opn@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
+            },
+            "osenv": {
+              "version": "0.1.0",
+              "from": "osenv@0.1.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+            },
+            "p-throttler": {
+              "version": "0.1.0",
+              "from": "p-throttler@0.1.0",
+              "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.0.tgz",
+              "dependencies": {
+                "q": {
+                  "version": "0.9.7",
+                  "from": "q@>=0.9.2 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+                }
+              }
+            },
+            "promptly": {
+              "version": "0.2.0",
+              "from": "promptly@0.2.0",
+              "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+              "dependencies": {
+                "read": {
+                  "version": "1.0.5",
+                  "from": "read@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+                  "dependencies": {
+                    "mute-stream": {
+                      "version": "0.0.4",
+                      "from": "mute-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "q": {
+              "version": "1.0.1",
+              "from": "q@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+            },
+            "request": {
+              "version": "2.42.0",
+              "from": "request@>=2.42.0 <2.43.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "qs": {
+                  "version": "1.2.2",
+                  "from": "qs@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@>=1.2.11 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.4.0",
+                  "from": "oauth-sign@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.3.0",
+              "from": "request-progress@0.3.0",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.0.tgz",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                }
+              }
+            },
+            "retry": {
+              "version": "0.6.0",
+              "from": "retry@0.6.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "semver": {
+              "version": "2.3.2",
+              "from": "semver@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+            },
+            "shell-quote": {
+              "version": "1.4.3",
+              "from": "shell-quote@>=1.4.1 <1.5.0",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                },
+                "array-filter": {
+                  "version": "0.0.1",
+                  "from": "array-filter@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                },
+                "array-reduce": {
+                  "version": "0.0.0",
+                  "from": "array-reduce@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                },
+                "array-map": {
+                  "version": "0.0.0",
+                  "from": "array-map@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                }
+              }
+            },
+            "stringify-object": {
+              "version": "1.0.1",
+              "from": "stringify-object@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
+            },
+            "tar-fs": {
+              "version": "0.5.2",
+              "from": "tar-fs@0.5.2",
+              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.5.2.tgz",
+              "dependencies": {
+                "pump": {
+                  "version": "0.3.5",
+                  "from": "pump@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.2.0",
+                      "from": "once@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
+                    },
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "from": "end-of-stream@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "tar-stream": {
+                  "version": "0.4.7",
+                  "from": "tar-stream@>=0.4.6 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "from": "bl@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                    },
+                    "end-of-stream": {
+                      "version": "1.1.0",
+                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "tmp": {
+              "version": "0.0.23",
+              "from": "tmp@0.0.23",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.23.tgz"
+            },
+            "update-notifier": {
+              "version": "0.2.0",
+              "from": "update-notifier@0.2.0",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.2.0.tgz",
+              "dependencies": {
+                "latest-version": {
+                  "version": "0.2.0",
+                  "from": "latest-version@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-0.2.0.tgz",
+                  "dependencies": {
+                    "package-json": {
+                      "version": "0.2.0",
+                      "from": "package-json@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/package-json/-/package-json-0.2.0.tgz",
+                      "dependencies": {
+                        "got": {
+                          "version": "0.3.0",
+                          "from": "got@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/got/-/got-0.3.0.tgz",
+                          "dependencies": {
+                            "object-assign": {
+                              "version": "0.3.1",
+                              "from": "object-assign@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-0.3.1.tgz"
+                            }
+                          }
+                        },
+                        "registry-url": {
+                          "version": "0.1.1",
+                          "from": "registry-url@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-0.1.1.tgz",
+                          "dependencies": {
+                            "npmconf": {
+                              "version": "2.1.1",
+                              "from": "npmconf@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+                              "dependencies": {
+                                "config-chain": {
+                                  "version": "1.1.8",
+                                  "from": "config-chain@>=1.1.8 <1.2.0",
+                                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                                  "dependencies": {
+                                    "proto-list": {
+                                      "version": "1.2.3",
+                                      "from": "proto-list@>=1.2.1 <1.3.0",
+                                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "ini": {
+                                  "version": "1.3.3",
+                                  "from": "ini@>=1.2.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                                },
+                                "once": {
+                                  "version": "1.3.1",
+                                  "from": "once@>=1.3.0 <1.4.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "uid-number": {
+                                  "version": "0.0.5",
+                                  "from": "uid-number@0.0.5",
+                                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver-diff": {
+                  "version": "0.1.0",
+                  "from": "semver-diff@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-0.1.0.tgz"
+                },
+                "string-length": {
+                  "version": "0.1.2",
+                  "from": "string-length@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "0.2.2",
+                      "from": "strip-ansi@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.2.2.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.1.0",
+                          "from": "ansi-regex@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            }
+          }
+        },
+        "bower-config": {
+          "version": "0.5.2",
+          "from": "bower-config@0.5.2",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            }
+          }
+        },
+        "broccoli": {
+          "version": "0.15.3",
+          "from": "broccoli@0.15.3",
+          "resolved": "https://registry.npmjs.org/broccoli/-/broccoli-0.15.3.tgz",
+          "dependencies": {
+            "broccoli-slow-trees": {
+              "version": "1.1.0",
+              "from": "broccoli-slow-trees@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz"
+            },
+            "commander": {
+              "version": "2.7.1",
+              "from": "commander@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "connect": {
+              "version": "3.3.5",
+              "from": "connect@>=3.2.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/connect/-/connect-3.3.5.tgz",
+              "dependencies": {
+                "finalhandler": {
+                  "version": "0.3.4",
+                  "from": "finalhandler@0.3.4",
+                  "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz",
+                  "dependencies": {
+                    "escape-html": {
+                      "version": "1.0.1",
+                      "from": "escape-html@1.0.1",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.2.0",
+                      "from": "on-finished@>=2.2.0 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.0",
+                          "from": "ee-first@1.1.0",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "parseurl": {
+                  "version": "1.3.0",
+                  "from": "parseurl@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "copy-dereference@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            },
+            "findup-sync": {
+              "version": "0.1.3",
+              "from": "findup-sync@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.9 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                }
+              }
+            },
+            "handlebars": {
+              "version": "2.0.0",
+              "from": "handlebars@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "mime@>=1.2.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            }
+          }
+        },
+        "broccoli-caching-writer": {
+          "version": "0.5.5",
+          "from": "broccoli-caching-writer@0.5.5",
+          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-0.5.5.tgz",
+          "dependencies": {
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.6",
+              "from": "broccoli-kitchen-sink-helpers@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "glob": {
+                  "version": "4.0.4",
+                  "from": "glob@4.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "core-object": {
+              "version": "0.0.3",
+              "from": "core-object@0.0.3",
+              "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.3.tgz"
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "lodash-node@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            },
+            "quick-temp": {
+              "version": "0.1.2",
+              "from": "quick-temp@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.6 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "mktemp@>=0.3.4 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@>=2.3.3 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.16 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            }
+          }
+        },
+        "broccoli-clean-css": {
+          "version": "0.2.0",
+          "from": "broccoli-clean-css@0.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-0.2.0.tgz",
+          "dependencies": {
+            "clean-css": {
+              "version": "2.2.23",
+              "from": "clean-css@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.2.0",
+                  "from": "commander@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-es3-safe-recast": {
+          "version": "2.0.0",
+          "from": "broccoli-es3-safe-recast@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-es3-safe-recast/-/broccoli-es3-safe-recast-2.0.0.tgz",
+          "dependencies": {
+            "es3-safe-recast": {
+              "version": "2.0.1",
+              "from": "es3-safe-recast@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/es3-safe-recast/-/es3-safe-recast-2.0.1.tgz",
+              "dependencies": {
+                "es-simpler-traverser": {
+                  "version": "0.0.1",
+                  "from": "es-simpler-traverser@0.0.1",
+                  "resolved": "https://registry.npmjs.org/es-simpler-traverser/-/es-simpler-traverser-0.0.1.tgz"
+                },
+                "recast": {
+                  "version": "0.9.18",
+                  "from": "recast@>=0.9.18 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "10001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=10001.1.0-dev-harmony-fb <10001.2.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "private": {
+                      "version": "0.1.6",
+                      "from": "private@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                    },
+                    "ast-types": {
+                      "version": "0.6.16",
+                      "from": "ast-types@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-filter": {
+              "version": "0.1.12",
+              "from": "broccoli-filter@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.12.tgz",
+              "dependencies": {
+                "quick-temp": {
+                  "version": "0.1.2",
+                  "from": "quick-temp@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "rimraf@>=2.2.6 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "mktemp@>=0.3.4 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@>=2.3.3 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "rsvp": {
+                  "version": "3.0.18",
+                  "from": "rsvp@>=3.0.16 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+                },
+                "walk-sync": {
+                  "version": "0.1.3",
+                  "from": "walk-sync@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+                },
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.2.6",
+                  "from": "broccoli-kitchen-sink-helpers@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.0.4",
+                      "from": "glob@4.0.4",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "3.0.6",
+                          "from": "graceful-fs@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "broccoli-es6modules": {
+          "version": "0.5.1",
+          "from": "broccoli-es6modules@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/broccoli-es6modules/-/broccoli-es6modules-0.5.1.tgz",
+          "dependencies": {
+            "broccoli-caching-writer": {
+              "version": "0.5.3",
+              "from": "broccoli-caching-writer@0.5.3",
+              "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-0.5.3.tgz",
+              "dependencies": {
+                "core-object": {
+                  "version": "0.0.2",
+                  "from": "core-object@0.0.2",
+                  "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
+                  "dependencies": {
+                    "lodash-node": {
+                      "version": "2.4.1",
+                      "from": "lodash-node@>=2.4.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+                    }
+                  }
+                },
+                "quick-temp": {
+                  "version": "0.1.2",
+                  "from": "quick-temp@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "rimraf@>=2.2.6 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "mktemp@>=0.3.4 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@>=2.3.3 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.6",
+              "from": "broccoli-kitchen-sink-helpers@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "glob": {
+                  "version": "4.0.4",
+                  "from": "glob@4.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esperanto": {
+              "version": "0.6.24",
+              "from": "esperanto@>=0.6.8 <0.7.0",
+              "resolved": "https://registry.npmjs.org/esperanto/-/esperanto-0.6.24.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "1.0.1",
+                  "from": "acorn@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.0.1.tgz"
+                },
+                "chalk": {
+                  "version": "1.0.0",
+                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.0.1",
+                      "from": "ansi-styles@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "1.0.3",
+                      "from": "has-ansi@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        },
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "1.3.1",
+                      "from": "supports-color@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                    }
+                  }
+                },
+                "magic-string": {
+                  "version": "0.4.6",
+                  "from": "magic-string@>=0.4.5 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.4.6.tgz",
+                  "dependencies": {
+                    "vlq": {
+                      "version": "0.2.1",
+                      "from": "vlq@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                },
+                "sander": {
+                  "version": "0.2.2",
+                  "from": "sander@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/sander/-/sander-0.2.2.tgz",
+                  "dependencies": {
+                    "es6-promise": {
+                      "version": "2.0.1",
+                      "from": "es6-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.0.1.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.4 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.16 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            },
+            "walk-sync": {
+              "version": "0.1.3",
+              "from": "walk-sync@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+            }
+          }
+        },
+        "broccoli-filter": {
+          "version": "0.1.12",
+          "from": "broccoli-filter@0.1.12",
+          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.12.tgz",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "0.2.2",
+          "from": "broccoli-funnel@0.2.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-0.2.2.tgz",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-kitchen-sink-helpers": {
+          "version": "0.2.6",
+          "from": "broccoli-kitchen-sink-helpers@0.2.6",
+          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "glob": {
+              "version": "4.0.4",
+              "from": "glob@4.0.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.6",
+                  "from": "graceful-fs@>=3.0.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "0.2.1",
+          "from": "broccoli-merge-trees@0.2.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-0.2.1.tgz"
+        },
+        "broccoli-sane-watcher": {
+          "version": "1.0.1",
+          "from": "broccoli-sane-watcher@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-sane-watcher/-/broccoli-sane-watcher-1.0.1.tgz",
+          "dependencies": {
+            "broccoli-slow-trees": {
+              "version": "1.1.0",
+              "from": "broccoli-slow-trees@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz"
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.16 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            },
+            "sane": {
+              "version": "1.0.2",
+              "from": "sane@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sane/-/sane-1.0.2.tgz",
+              "dependencies": {
+                "fb-watchman": {
+                  "version": "0.0.0",
+                  "from": "fb-watchman@0.0.0",
+                  "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-0.0.0.tgz",
+                  "dependencies": {
+                    "json-stream": {
+                      "version": "0.2.2",
+                      "from": "json-stream@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-stream/-/json-stream-0.2.2.tgz"
+                    },
+                    "nextback": {
+                      "version": "0.1.0",
+                      "from": "nextback@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/nextback/-/nextback-0.1.0.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.14 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "walker": {
+                  "version": "1.0.6",
+                  "from": "walker@>=1.0.5 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.6.tgz",
+                  "dependencies": {
+                    "makeerror": {
+                      "version": "1.0.11",
+                      "from": "makeerror@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+                      "dependencies": {
+                        "tmpl": {
+                          "version": "1.0.4",
+                          "from": "tmpl@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "watch": {
+                  "version": "0.10.0",
+                  "from": "watch@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "broccoli-sourcemap-concat": {
+          "version": "0.4.3",
+          "from": "broccoli-sourcemap-concat@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/broccoli-sourcemap-concat/-/broccoli-sourcemap-concat-0.4.3.tgz",
+          "dependencies": {
+            "broccoli-caching-writer": {
+              "version": "0.5.3",
+              "from": "broccoli-caching-writer@0.5.3",
+              "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-0.5.3.tgz",
+              "dependencies": {
+                "core-object": {
+                  "version": "0.0.2",
+                  "from": "core-object@0.0.2",
+                  "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz"
+                },
+                "quick-temp": {
+                  "version": "0.1.2",
+                  "from": "quick-temp@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "rimraf@>=2.2.6 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "mktemp@>=0.3.4 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@>=2.3.3 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.6",
+              "from": "broccoli-kitchen-sink-helpers@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "glob": {
+                  "version": "4.0.4",
+                  "from": "glob@4.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@0.0.7",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "fast-sourcemap-concat": {
+              "version": "0.2.3",
+              "from": "fast-sourcemap-concat@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-0.2.3.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "from": "chalk@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "source-map-url": {
+                  "version": "0.3.0",
+                  "from": "source-map-url@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "lodash-node@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.16 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            }
+          }
+        },
+        "broccoli-unwatched-tree": {
+          "version": "0.1.1",
+          "from": "broccoli-unwatched-tree@0.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.1.tgz"
+        },
+        "broccoli-writer": {
+          "version": "0.1.1",
+          "from": "broccoli-writer@0.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+          "dependencies": {
+            "quick-temp": {
+              "version": "0.1.2",
+              "from": "quick-temp@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.6 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "mktemp@>=0.3.4 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@>=2.3.3 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.16 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@1.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.4.7",
+          "from": "concat-stream@>=1.4.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            }
+          }
+        },
+        "configstore": {
+          "version": "0.3.2",
+          "from": "configstore@0.3.2",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "graceful-fs@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "js-yaml": {
+              "version": "3.2.7",
+              "from": "js-yaml@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.0.0",
+                  "from": "esprima@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "osenv": {
+              "version": "0.1.0",
+              "from": "osenv@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+            },
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "from": "uuid@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+            },
+            "xdg-basedir": {
+              "version": "1.0.1",
+              "from": "xdg-basedir@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+            }
+          }
+        },
+        "core-object": {
+          "version": "0.0.2",
+          "from": "core-object@0.0.2",
+          "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
+          "dependencies": {
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "lodash-node@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.1.3",
+          "from": "debug@>=2.1.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.0",
+              "from": "ms@0.7.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.3.1",
+          "from": "diff@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.1.tgz"
+        },
+        "ember-cli-copy-dereference": {
+          "version": "1.0.0",
+          "from": "ember-cli-copy-dereference@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-copy-dereference/-/ember-cli-copy-dereference-1.0.0.tgz"
+        },
+        "ember-router-generator": {
+          "version": "0.3.2",
+          "from": "ember-router-generator@>=0.3.2 <0.4.0",
+          "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-0.3.2.tgz",
+          "dependencies": {
+            "recast": {
+              "version": "0.9.18",
+              "from": "recast@>=0.9.18 <0.10.0",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
+              "dependencies": {
+                "esprima-fb": {
+                  "version": "10001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@>=10001.1.0-dev-harmony-fb <10001.2.0",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.40 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "private@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "ast-types": {
+                  "version": "0.6.16",
+                  "from": "ast-types@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz"
+                }
+              }
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "express": {
+          "version": "4.12.3",
+          "from": "express@>=4.12.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.12.3.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.5",
+              "from": "accepts@>=1.2.5 <1.3.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.0.10",
+                  "from": "mime-types@>=2.0.10 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.5.1",
+                  "from": "negotiator@0.5.1",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
+                }
+              }
+            },
+            "content-disposition": {
+              "version": "0.5.0",
+              "from": "content-disposition@0.5.0",
+              "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+            },
+            "content-type": {
+              "version": "1.0.1",
+              "from": "content-type@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "from": "cookie-signature@1.0.6",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+            },
+            "depd": {
+              "version": "1.0.0",
+              "from": "depd@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+            },
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+            },
+            "etag": {
+              "version": "1.5.1",
+              "from": "etag@>=1.5.1 <1.6.0",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+              "dependencies": {
+                "crc": {
+                  "version": "3.2.1",
+                  "from": "crc@3.2.1",
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.3.4",
+              "from": "finalhandler@0.3.4",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz"
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "from": "fresh@0.2.4",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+            },
+            "merge-descriptors": {
+              "version": "1.0.0",
+              "from": "merge-descriptors@1.0.0",
+              "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+            },
+            "methods": {
+              "version": "1.1.1",
+              "from": "methods@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+            },
+            "on-finished": {
+              "version": "2.2.0",
+              "from": "on-finished@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "from": "ee-first@1.1.0",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "path-to-regexp": {
+              "version": "0.1.3",
+              "from": "path-to-regexp@0.1.3",
+              "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+            },
+            "proxy-addr": {
+              "version": "1.0.7",
+              "from": "proxy-addr@>=1.0.7 <1.1.0",
+              "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz",
+              "dependencies": {
+                "forwarded": {
+                  "version": "0.1.0",
+                  "from": "forwarded@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+                },
+                "ipaddr.js": {
+                  "version": "0.1.9",
+                  "from": "ipaddr.js@0.1.9",
+                  "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "2.4.1",
+              "from": "qs@2.4.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+            },
+            "range-parser": {
+              "version": "1.0.2",
+              "from": "range-parser@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+            },
+            "send": {
+              "version": "0.12.2",
+              "from": "send@0.12.2",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.12.2.tgz",
+              "dependencies": {
+                "destroy": {
+                  "version": "1.0.3",
+                  "from": "destroy@1.0.3",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.9.2",
+              "from": "serve-static@>=1.9.2 <1.10.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
+            },
+            "type-is": {
+              "version": "1.6.1",
+              "from": "type-is@>=1.6.1 <1.7.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.10",
+                  "from": "mime-types@>=2.0.10 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "vary": {
+              "version": "1.0.0",
+              "from": "vary@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            }
+          }
+        },
+        "findup": {
+          "version": "0.1.5",
+          "from": "findup@0.1.5",
+          "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "from": "colors@>=0.6.0-1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+            },
+            "commander": {
+              "version": "2.1.0",
+              "from": "commander@>=2.1.0 <2.2.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "0.16.5",
+          "from": "fs-extra@0.16.5",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "jsonfile": {
+              "version": "2.0.0",
+              "from": "jsonfile@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
+            }
+          }
+        },
+        "git-repo-info": {
+          "version": "1.0.4",
+          "from": "git-repo-info@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.0.4.tgz"
+        },
+        "glob": {
+          "version": "5.0.3",
+          "from": "glob@5.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "1.9.0",
+          "from": "http-proxy@>=1.9.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.9.0.tgz",
+          "dependencies": {
+            "eventemitter3": {
+              "version": "0.1.6",
+              "from": "eventemitter3@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+            },
+            "requires-port": {
+              "version": "0.0.0",
+              "from": "requires-port@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+            }
+          }
+        },
+        "inflection": {
+          "version": "1.7.0",
+          "from": "inflection@>=1.7.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.7.0.tgz"
+        },
+        "inquirer": {
+          "version": "0.5.1",
+          "from": "inquirer@0.5.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.5.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.8.0",
+              "from": "async@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz"
+            },
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "cli-color@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.6",
+                  "from": "es5-ext@>=0.10.6 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "from": "memoizee@>=0.3.8 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.2",
+                      "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "0.1.1",
+                          "from": "es6-symbol@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "lru-queue@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "from": "chalk@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "has-color@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "ansi-styles@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "strip-ansi@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "js-string-escape": {
+          "version": "1.0.0",
+          "from": "js-string-escape@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
+        },
+        "leek": {
+          "version": "0.0.18",
+          "from": "leek@0.0.18",
+          "resolved": "https://registry.npmjs.org/leek/-/leek-0.0.18.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.1.1",
+              "from": "debug@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "lodash-node@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            },
+            "request": {
+              "version": "2.53.0",
+              "from": "request@>=2.27.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.9",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.9.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "from": "mime-db@>=1.7.0 <1.8.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.7.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.11.1",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.1.tgz"
+                    },
+                    "boom": {
+                      "version": "2.6.1",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.17",
+              "from": "rsvp@>=3.0.6 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.17.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.6.0",
+          "from": "lodash@>=3.6.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+        },
+        "markdown-it": {
+          "version": "4.0.3",
+          "from": "markdown-it@4.0.3",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.0.3.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "from": "argparse@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.6.0",
+                  "from": "lodash@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                },
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.1.1",
+              "from": "entities@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+            },
+            "linkify-it": {
+              "version": "1.0.0",
+              "from": "linkify-it@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.0.0.tgz"
+            },
+            "mdurl": {
+              "version": "1.0.0",
+              "from": "mdurl@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.0.tgz"
+            },
+            "uc.micro": {
+              "version": "1.0.0",
+              "from": "uc.micro@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.0.tgz"
+            }
+          }
+        },
+        "markdown-it-terminal": {
+          "version": "0.0.2",
+          "from": "markdown-it-terminal@0.0.2",
+          "resolved": "https://registry.npmjs.org/markdown-it-terminal/-/markdown-it-terminal-0.0.2.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "cardinal": {
+              "version": "0.5.0",
+              "from": "cardinal@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
+              "dependencies": {
+                "redeyed": {
+                  "version": "0.5.0",
+                  "from": "redeyed@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "12001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=12001.1.0-dev-harmony-fb <12001.2.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
+                    }
+                  }
+                },
+                "ansicolors": {
+                  "version": "0.2.1",
+                  "from": "ansicolors@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+                }
+              }
+            },
+            "cli-table": {
+              "version": "0.3.1",
+              "from": "cli-table@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+              "dependencies": {
+                "colors": {
+                  "version": "1.0.3",
+                  "from": "colors@1.0.3",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "3.6.0",
+              "from": "lodash-node@>=3.4.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-3.6.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.4",
+          "from": "minimatch@>=2.0.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "morgan": {
+          "version": "1.5.2",
+          "from": "morgan@>=1.5.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.2.tgz",
+          "dependencies": {
+            "basic-auth": {
+              "version": "1.0.0",
+              "from": "basic-auth@1.0.0",
+              "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+            },
+            "depd": {
+              "version": "1.0.0",
+              "from": "depd@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+            },
+            "on-finished": {
+              "version": "2.2.0",
+              "from": "on-finished@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "from": "ee-first@1.1.0",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.3",
+          "from": "node-uuid@>=1.4.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+        },
+        "nopt": {
+          "version": "3.0.1",
+          "from": "nopt@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+        },
+        "npm": {
+          "version": "2.7.4",
+          "from": "npm@>=2.7.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-2.7.4.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@latest",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "ansi": {
+              "version": "0.3.0",
+              "from": "ansi@latest",
+              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+            },
+            "ansicolors": {
+              "version": "0.3.2",
+              "from": "ansicolors@latest"
+            },
+            "ansistyles": {
+              "version": "0.1.3",
+              "from": "ansistyles@0.1.3",
+              "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz"
+            },
+            "archy": {
+              "version": "1.0.0",
+              "from": "archy@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+            },
+            "async-some": {
+              "version": "1.0.1",
+              "from": "async-some@>=1.0.1-0 <2.0.0-0",
+              "resolved": "https://registry.npmjs.org/async-some/-/async-some-1.0.1.tgz"
+            },
+            "block-stream": {
+              "version": "0.0.7",
+              "from": "block-stream@latest"
+            },
+            "char-spinner": {
+              "version": "1.0.1",
+              "from": "char-spinner@latest",
+              "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
+            },
+            "child-process-close": {
+              "version": "0.1.1",
+              "from": "child-process-close@",
+              "resolved": "https://registry.npmjs.org/child-process-close/-/child-process-close-0.1.1.tgz"
+            },
+            "chmodr": {
+              "version": "0.1.0",
+              "from": "chmodr@latest"
+            },
+            "chownr": {
+              "version": "0.0.1",
+              "from": "../chownr"
+            },
+            "cmd-shim": {
+              "version": "2.0.1",
+              "from": "cmd-shim@>=2.0.1-0 <3.0.0-0",
+              "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.1.tgz"
+            },
+            "columnify": {
+              "version": "1.4.1",
+              "from": "columnify@>=1.4.1 <1.5.0",
+              "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.4.1.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.0",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
+                    }
+                  }
+                },
+                "wcwidth": {
+                  "version": "1.0.0",
+                  "from": "wcwidth@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
+                  "dependencies": {
+                    "defaults": {
+                      "version": "1.0.0",
+                      "from": "defaults@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.0.tgz",
+                      "dependencies": {
+                        "clone": {
+                          "version": "0.1.19",
+                          "from": "clone@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "config-chain": {
+              "version": "1.1.8",
+              "from": "config-chain@^1.1.8",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.3",
+                  "from": "proto-list@~1.2.1",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                }
+              }
+            },
+            "dezalgo": {
+              "version": "1.0.1",
+              "from": "dezalgo@latest",
+              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.1.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "from": "asap@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                }
+              }
+            },
+            "editor": {
+              "version": "0.1.0",
+              "from": "editor@latest",
+              "resolved": "https://registry.npmjs.org/editor/-/editor-0.1.0.tgz"
+            },
+            "fs-vacuum": {
+              "version": "1.2.5",
+              "from": "fs-vacuum@~1.2.5"
+            },
+            "fs-write-stream-atomic": {
+              "version": "1.0.2",
+              "from": "fs-write-stream-atomic@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.2.tgz"
+            },
+            "fstream": {
+              "version": "1.0.4",
+              "from": "fstream@>=1.0.4 <1.1.0"
+            },
+            "fstream-npm": {
+              "version": "1.0.2",
+              "from": "fstream-npm@>=1.0.2 <1.1.0",
+              "dependencies": {
+                "fstream-ignore": {
+                  "version": "1.0.2",
+                  "from": "fstream-ignore@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz"
+                }
+              }
+            },
+            "github-url-from-git": {
+              "version": "1.4.0",
+              "from": "github-url-from-git@>=1.4.0-0 <2.0.0-0",
+              "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
+            },
+            "github-url-from-username-repo": {
+              "version": "1.0.2",
+              "from": "github-url-from-username-repo@>=1.0.2-0 <2.0.0-0"
+            },
+            "glob": {
+              "version": "5.0.3",
+              "from": "glob@>=5.0.3 <5.1.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz"
+            },
+            "graceful-fs": {
+              "version": "3.0.6",
+              "from": "graceful-fs@>=3.0.6 <3.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+            },
+            "hosted-git-info": {
+              "version": "1.5.3",
+              "from": "hosted-git-info@>=1.5.3 <1.6.0",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-1.5.3.tgz"
+            },
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <1.1.0"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@latest",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "ini": {
+              "version": "1.3.3",
+              "from": "ini@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+            },
+            "init-package-json": {
+              "version": "1.3.0",
+              "from": "init-package-json@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.3.0.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.4.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+                },
+                "promzard": {
+                  "version": "0.2.2",
+                  "from": "promzard@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.2.2.tgz"
+                }
+              }
+            },
+            "lockfile": {
+              "version": "1.0.0",
+              "from": "lockfile@1.0.0",
+              "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.0.tgz"
+            },
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@latest"
+            },
+            "minimatch": {
+              "version": "2.0.4",
+              "from": "minimatch@>=2.0.4 <2.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@latest",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "node-gyp": {
+              "version": "1.0.3",
+              "from": "node-gyp@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-1.0.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.4.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@latest"
+            },
+            "normalize-git-url": {
+              "version": "1.0.0",
+              "from": "normalize-git-url@>=1.0.0 <1.1.0"
+            },
+            "normalize-package-data": {
+              "version": "1.0.3",
+              "from": "normalize-package-data@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-1.0.3.tgz"
+            },
+            "npm-cache-filename": {
+              "version": "1.0.1",
+              "from": "npm-cache-filename@latest",
+              "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.1.tgz"
+            },
+            "npm-install-checks": {
+              "version": "1.0.5",
+              "from": "npm-install-checks@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.5.tgz"
+            },
+            "npm-package-arg": {
+              "version": "3.1.1",
+              "from": "npm-package-arg@>=3.1.1 <3.2.0",
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-3.1.1.tgz"
+            },
+            "npm-registry-client": {
+              "version": "6.1.2",
+              "from": "npm-registry-client@>=6.1.2 <7.0.0",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.4.7",
+                  "from": "concat-stream@>=1.4.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-user-validate": {
+              "version": "0.1.1",
+              "from": "npm-user-validate@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.1.tgz"
+            },
+            "npmlog": {
+              "version": "1.2.0",
+              "from": "npmlog@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.0.tgz",
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.0.3",
+                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.3.tgz",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    }
+                  }
+                },
+                "gauge": {
+                  "version": "1.2.0",
+                  "from": "gauge@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.0.tgz",
+                  "dependencies": {
+                    "has-unicode": {
+                      "version": "1.0.0",
+                      "from": "has-unicode@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "3.0.0",
+                      "from": "lodash.pad@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.0.0.tgz"
+                    },
+                    "lodash.padleft": {
+                      "version": "3.0.0",
+                      "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.0.0.tgz"
+                    },
+                    "lodash.padright": {
+                      "version": "3.0.0",
+                      "from": "lodash.padright@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.0.0.tgz"
+                    },
+                    "lodash._basetostring": {
+                      "version": "3.0.0",
+                      "from": "lodash._basetostring@3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                    },
+                    "lodash._createpad": {
+                      "version": "3.0.1",
+                      "from": "lodash._createpad@3.0.1",
+                      "resolved": "https://registry.npmjs.org/lodash._createpad/-/lodash._createpad-3.0.1.tgz",
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.0",
+                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@>=1.3.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz"
+            },
+            "opener": {
+              "version": "1.4.0",
+              "from": "opener@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.0.tgz"
+            },
+            "osenv": {
+              "version": "0.1.0",
+              "from": "osenv@~0.1.0"
+            },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "from": "path-is-inside@1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+            },
+            "read": {
+              "version": "1.0.5",
+              "from": "read@latest",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@~0.0.4"
+                }
+              }
+            },
+            "read-installed": {
+              "version": "3.1.5",
+              "from": "read-installed@>=3.1.5 <3.2.0",
+              "dependencies": {
+                "debuglog": {
+                  "version": "1.0.1",
+                  "from": "debuglog@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz"
+                },
+                "readdir-scoped-modules": {
+                  "version": "1.0.1",
+                  "from": "readdir-scoped-modules@>=1.0.0 <2.0.0"
+                },
+                "util-extend": {
+                  "version": "1.0.1",
+                  "from": "util-extend@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz"
+                }
+              }
+            },
+            "read-package-json": {
+              "version": "1.3.2",
+              "from": "read-package-json@>=1.3.2 <1.4.0",
+              "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.3.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.4.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+                },
+                "json-parse-helpfulerror": {
+                  "version": "1.0.3",
+                  "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
+                  "dependencies": {
+                    "jju": {
+                      "version": "1.2.0",
+                      "from": "jju@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jju/-/jju-1.2.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            },
+            "realize-package-specifier": {
+              "version": "2.2.0",
+              "from": "realize-package-specifier@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-2.2.0.tgz"
+            },
+            "request": {
+              "version": "2.53.0",
+              "from": "request@>=2.53.0 <2.54.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.8",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.8.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.6.1",
+                      "from": "mime-db@>=1.6.0 <1.7.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.6.1.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@>=2.3.1 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.11.0",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.11.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.6.1",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.6.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.1",
+                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
+                }
+              }
+            },
+            "retry": {
+              "version": "0.6.1",
+              "from": "retry@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
+            },
+            "rimraf": {
+              "version": "2.3.2",
+              "from": "rimraf@>=2.3.2 <2.4.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.4.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.1",
+              "from": "semver@>=4.3.1 <4.4.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.1.tgz"
+            },
+            "sha": {
+              "version": "1.3.0",
+              "from": "sha@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/sha/-/sha-1.3.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "slide": {
+              "version": "1.1.6",
+              "from": "slide@>=1.1.6 <1.2.0",
+              "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+            },
+            "sorted-object": {
+              "version": "1.0.0",
+              "from": "sorted-object@"
+            },
+            "tar": {
+              "version": "1.0.3",
+              "from": "tar@>=1.0.3 <1.1.0"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@~0.2.0"
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "from": "uid-number@>=0.0.6 <0.1.0",
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+            },
+            "umask": {
+              "version": "1.1.0",
+              "from": "umask@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz"
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.9 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            },
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@1.0.1",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            },
+            "write-file-atomic": {
+              "version": "1.1.0",
+              "from": "write-file-atomic@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.0.tgz"
+            }
+          }
+        },
+        "pleasant-progress": {
+          "version": "1.0.2",
+          "from": "pleasant-progress@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pleasant-progress/-/pleasant-progress-1.0.2.tgz"
+        },
+        "promise-map-series": {
+          "version": "0.2.1",
+          "from": "promise-map-series@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.1.tgz",
+          "dependencies": {
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.16 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            }
+          }
+        },
+        "proxy-middleware": {
+          "version": "0.11.0",
+          "from": "proxy-middleware@0.11.0",
+          "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.11.0.tgz"
+        },
+        "quick-temp": {
+          "version": "0.1.2",
+          "from": "quick-temp@0.1.2",
+          "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.6 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "mktemp": {
+              "version": "0.3.5",
+              "from": "mktemp@>=0.3.4 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "from": "readline2@0.1.1",
+          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "mute-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.6",
+          "from": "resolve@>=1.1.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+        },
+        "rimraf": {
+          "version": "2.3.2",
+          "from": "rimraf@2.3.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.4.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.0.18",
+          "from": "rsvp@>=3.0.17 <4.0.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+        },
+        "sane": {
+          "version": "1.0.1",
+          "from": "sane@1.0.1",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-1.0.1.tgz",
+          "dependencies": {
+            "fb-watchman": {
+              "version": "0.0.0",
+              "from": "fb-watchman@0.0.0",
+              "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-0.0.0.tgz",
+              "dependencies": {
+                "json-stream": {
+                  "version": "0.2.2",
+                  "from": "json-stream@0.2.2",
+                  "resolved": "https://registry.npmjs.org/json-stream/-/json-stream-0.2.2.tgz"
+                },
+                "nextback": {
+                  "version": "0.1.0",
+                  "from": "nextback@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/nextback/-/nextback-0.1.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.14 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "walker": {
+              "version": "1.0.6",
+              "from": "walker@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.6.tgz",
+              "dependencies": {
+                "makeerror": {
+                  "version": "1.0.11",
+                  "from": "makeerror@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+                  "dependencies": {
+                    "tmpl": {
+                      "version": "1.0.4",
+                      "from": "tmpl@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "watch": {
+              "version": "0.10.0",
+              "from": "watch@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
+            }
+          }
+        },
+        "semver": {
+          "version": "4.3.3",
+          "from": "semver@>=4.3.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "from": "strip-ansi@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            }
+          }
+        },
+        "symlink-or-copy": {
+          "version": "1.0.1",
+          "from": "symlink-or-copy@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+          "dependencies": {
+            "copy-dereference": {
+              "version": "1.0.0",
+              "from": "copy-dereference@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+            }
+          }
+        },
+        "temp": {
+          "version": "0.8.1",
+          "from": "temp@0.8.1",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.6 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        },
+        "testem": {
+          "version": "0.7.6",
+          "from": "testem@>=0.7.6 <0.8.0",
+          "resolved": "https://registry.npmjs.org/testem/-/testem-0.7.6.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "backbone": {
+              "version": "1.1.2",
+              "from": "backbone@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.8.2",
+                  "from": "underscore@>=1.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz"
+                }
+              }
+            },
+            "charm": {
+              "version": "1.0.0",
+              "from": "charm@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.0.tgz"
+            },
+            "colors": {
+              "version": "1.0.3",
+              "from": "colors@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+            },
+            "commander": {
+              "version": "2.7.1",
+              "from": "commander@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "consolidate": {
+              "version": "0.11.0",
+              "from": "consolidate@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.11.0.tgz"
+            },
+            "cross-spawn": {
+              "version": "0.2.8",
+              "from": "cross-spawn@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.8.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.5.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                }
+              }
+            },
+            "did_it_work": {
+              "version": "0.0.6",
+              "from": "did_it_work@0.0.6",
+              "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz"
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "from": "fileset@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.4.0",
+                  "from": "minimatch@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "fireworm": {
+              "version": "0.6.6",
+              "from": "fireworm@>=0.6.6 <0.7.0",
+              "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.6.6.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.9 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.9 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "lodash": {
+                  "version": "2.3.0",
+                  "from": "lodash@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.3.0.tgz"
+                },
+                "is-type": {
+                  "version": "0.0.1",
+                  "from": "is-type@0.0.1",
+                  "resolved": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.3.5 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "growl": {
+              "version": "1.8.1",
+              "from": "growl@>=1.8.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+            },
+            "js-yaml": {
+              "version": "3.2.7",
+              "from": "js-yaml@>=3.2.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "argparse@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.0.0",
+                  "from": "esprima@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "mustache": {
+              "version": "1.2.0",
+              "from": "mustache@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.2.0.tgz"
+            },
+            "npmlog": {
+              "version": "1.2.0",
+              "from": "npmlog@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.0.tgz",
+              "dependencies": {
+                "ansi": {
+                  "version": "0.3.0",
+                  "from": "ansi@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                },
+                "are-we-there-yet": {
+                  "version": "1.0.3",
+                  "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.3.tgz",
+                  "dependencies": {
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    }
+                  }
+                },
+                "gauge": {
+                  "version": "1.2.0",
+                  "from": "gauge@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.0.tgz",
+                  "dependencies": {
+                    "has-unicode": {
+                      "version": "1.0.0",
+                      "from": "has-unicode@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "3.1.0",
+                      "from": "lodash.pad@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.0.tgz",
+                      "dependencies": {
+                        "lodash._basetostring": {
+                          "version": "3.0.0",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                        },
+                        "lodash._createpadding": {
+                          "version": "3.6.0",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.0.tgz",
+                          "dependencies": {
+                            "lodash.repeat": {
+                              "version": "3.0.0",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.padleft": {
+                      "version": "3.1.0",
+                      "from": "lodash.padleft@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.0.tgz",
+                      "dependencies": {
+                        "lodash._basetostring": {
+                          "version": "3.0.0",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                        },
+                        "lodash._createpadding": {
+                          "version": "3.6.0",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.0.tgz",
+                          "dependencies": {
+                            "lodash.repeat": {
+                              "version": "3.0.0",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.padright": {
+                      "version": "3.1.0",
+                      "from": "lodash.padright@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.0.tgz",
+                      "dependencies": {
+                        "lodash._basetostring": {
+                          "version": "3.0.0",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                        },
+                        "lodash._createpadding": {
+                          "version": "3.6.0",
+                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.0.tgz",
+                          "dependencies": {
+                            "lodash.repeat": {
+                              "version": "3.0.0",
+                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "socket.io": {
+              "version": "1.3.5",
+              "from": "socket.io@>=1.3.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.5.tgz",
+              "dependencies": {
+                "engine.io": {
+                  "version": "1.5.1",
+                  "from": "engine.io@1.5.1",
+                  "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.1.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "1.0.3",
+                      "from": "debug@1.0.3",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "ms@0.6.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                      }
+                    },
+                    "ws": {
+                      "version": "0.5.0",
+                      "from": "ws@0.5.0",
+                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.5.0.tgz",
+                      "dependencies": {
+                        "nan": {
+                          "version": "1.4.3",
+                          "from": "nan@>=1.4.0 <1.5.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
+                        },
+                        "options": {
+                          "version": "0.0.6",
+                          "from": "options@>=0.0.5",
+                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                        },
+                        "ultron": {
+                          "version": "1.0.1",
+                          "from": "ultron@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "engine.io-parser": {
+                      "version": "1.2.1",
+                      "from": "engine.io-parser@1.2.1",
+                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+                      "dependencies": {
+                        "after": {
+                          "version": "0.8.1",
+                          "from": "after@0.8.1",
+                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                        },
+                        "arraybuffer.slice": {
+                          "version": "0.0.6",
+                          "from": "arraybuffer.slice@0.0.6",
+                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                        },
+                        "base64-arraybuffer": {
+                          "version": "0.1.2",
+                          "from": "base64-arraybuffer@0.1.2",
+                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                        },
+                        "blob": {
+                          "version": "0.0.2",
+                          "from": "blob@0.0.2",
+                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                        },
+                        "has-binary": {
+                          "version": "0.1.5",
+                          "from": "has-binary@0.1.5",
+                          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+                          "dependencies": {
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            }
+                          }
+                        },
+                        "utf8": {
+                          "version": "2.0.0",
+                          "from": "utf8@2.0.0",
+                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "base64id": {
+                      "version": "0.1.0",
+                      "from": "base64id@0.1.0",
+                      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                    }
+                  }
+                },
+                "socket.io-parser": {
+                  "version": "2.2.4",
+                  "from": "socket.io-parser@2.2.4",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@0.7.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "json3@3.2.6",
+                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "component-emitter@1.1.2",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "benchmark": {
+                      "version": "1.0.0",
+                      "from": "benchmark@1.0.0",
+                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                    }
+                  }
+                },
+                "socket.io-client": {
+                  "version": "1.3.5",
+                  "from": "socket.io-client@1.3.5",
+                  "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.5.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@0.7.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "engine.io-client": {
+                      "version": "1.5.1",
+                      "from": "engine.io-client@1.5.1",
+                      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.5.1.tgz",
+                      "dependencies": {
+                        "has-cors": {
+                          "version": "1.0.3",
+                          "from": "has-cors@1.0.3",
+                          "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
+                          "dependencies": {
+                            "global": {
+                              "version": "2.0.1",
+                              "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+                              "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                            }
+                          }
+                        },
+                        "ws": {
+                          "version": "0.4.31",
+                          "from": "ws@0.4.31",
+                          "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                          "dependencies": {
+                            "commander": {
+                              "version": "0.6.1",
+                              "from": "commander@>=0.6.1 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                            },
+                            "nan": {
+                              "version": "0.3.2",
+                              "from": "nan@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                            },
+                            "tinycolor": {
+                              "version": "0.0.1",
+                              "from": "tinycolor@>=0.0.0 <1.0.0",
+                              "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                            },
+                            "options": {
+                              "version": "0.0.6",
+                              "from": "options@>=0.0.5",
+                              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                            }
+                          }
+                        },
+                        "xmlhttprequest": {
+                          "version": "1.5.0",
+                          "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
+                          "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+                        },
+                        "engine.io-parser": {
+                          "version": "1.2.1",
+                          "from": "engine.io-parser@1.2.1",
+                          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+                          "dependencies": {
+                            "after": {
+                              "version": "0.8.1",
+                              "from": "after@0.8.1",
+                              "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                            },
+                            "arraybuffer.slice": {
+                              "version": "0.0.6",
+                              "from": "arraybuffer.slice@0.0.6",
+                              "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                            },
+                            "base64-arraybuffer": {
+                              "version": "0.1.2",
+                              "from": "base64-arraybuffer@0.1.2",
+                              "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                            },
+                            "blob": {
+                              "version": "0.0.2",
+                              "from": "blob@0.0.2",
+                              "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                            },
+                            "has-binary": {
+                              "version": "0.1.5",
+                              "from": "has-binary@0.1.5",
+                              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+                              "dependencies": {
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                }
+                              }
+                            },
+                            "utf8": {
+                              "version": "2.0.0",
+                              "from": "utf8@2.0.0",
+                              "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "1.0.4",
+                          "from": "debug@1.0.4",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.6.2",
+                              "from": "ms@0.6.2",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                            }
+                          }
+                        },
+                        "parseuri": {
+                          "version": "0.0.4",
+                          "from": "parseuri@0.0.4",
+                          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                          "dependencies": {
+                            "better-assert": {
+                              "version": "1.0.2",
+                              "from": "better-assert@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "dependencies": {
+                                "callsite": {
+                                  "version": "1.0.0",
+                                  "from": "callsite@1.0.0",
+                                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "parsejson": {
+                          "version": "0.0.1",
+                          "from": "parsejson@0.0.1",
+                          "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                          "dependencies": {
+                            "better-assert": {
+                              "version": "1.0.2",
+                              "from": "better-assert@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "dependencies": {
+                                "callsite": {
+                                  "version": "1.0.0",
+                                  "from": "callsite@1.0.0",
+                                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "parseqs": {
+                          "version": "0.0.2",
+                          "from": "parseqs@0.0.2",
+                          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                          "dependencies": {
+                            "better-assert": {
+                              "version": "1.0.2",
+                              "from": "better-assert@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "dependencies": {
+                                "callsite": {
+                                  "version": "1.0.0",
+                                  "from": "callsite@1.0.0",
+                                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "component-inherit": {
+                          "version": "0.0.3",
+                          "from": "component-inherit@0.0.3",
+                          "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                        }
+                      }
+                    },
+                    "component-bind": {
+                      "version": "1.0.0",
+                      "from": "component-bind@1.0.0",
+                      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "component-emitter@1.1.2",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "object-component": {
+                      "version": "0.0.3",
+                      "from": "object-component@0.0.3",
+                      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+                    },
+                    "has-binary": {
+                      "version": "0.1.6",
+                      "from": "has-binary@0.1.6",
+                      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "indexof@0.0.1",
+                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    },
+                    "parseuri": {
+                      "version": "0.0.2",
+                      "from": "parseuri@0.0.2",
+                      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-array": {
+                      "version": "0.1.3",
+                      "from": "to-array@0.1.3",
+                      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+                    },
+                    "backo2": {
+                      "version": "1.0.2",
+                      "from": "backo2@1.0.2",
+                      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+                    }
+                  }
+                },
+                "socket.io-adapter": {
+                  "version": "0.3.1",
+                  "from": "socket.io-adapter@0.3.1",
+                  "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "1.0.2",
+                      "from": "debug@1.0.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "ms@0.6.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                      }
+                    },
+                    "socket.io-parser": {
+                      "version": "2.2.2",
+                      "from": "socket.io-parser@2.2.2",
+                      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                      "dependencies": {
+                        "debug": {
+                          "version": "0.7.4",
+                          "from": "debug@0.7.4",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                        },
+                        "json3": {
+                          "version": "3.2.6",
+                          "from": "json3@3.2.6",
+                          "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                        },
+                        "component-emitter": {
+                          "version": "1.1.2",
+                          "from": "component-emitter@1.1.2",
+                          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "benchmark": {
+                          "version": "1.0.0",
+                          "from": "benchmark@1.0.0",
+                          "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "object-keys": {
+                      "version": "1.0.1",
+                      "from": "object-keys@1.0.1",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
+                    }
+                  }
+                },
+                "has-binary-data": {
+                  "version": "0.1.3",
+                  "from": "has-binary-data@0.1.3",
+                  "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.1.0",
+                  "from": "debug@2.1.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "styled_string": {
+              "version": "0.0.1",
+              "from": "styled_string@0.0.1",
+              "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz"
+            },
+            "tap": {
+              "version": "0.6.0",
+              "from": "tap@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/tap/-/tap-0.6.0.tgz",
+              "dependencies": {
+                "buffer-equal": {
+                  "version": "0.0.1",
+                  "from": "buffer-equal@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
+                },
+                "deep-equal": {
+                  "version": "1.0.0",
+                  "from": "deep-equal@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                },
+                "difflet": {
+                  "version": "0.2.6",
+                  "from": "difflet@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.6.6",
+                      "from": "traverse@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+                    },
+                    "charm": {
+                      "version": "0.1.2",
+                      "from": "charm@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "runforcover": {
+                  "version": "0.0.2",
+                  "from": "runforcover@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+                  "dependencies": {
+                    "bunker": {
+                      "version": "0.1.2",
+                      "from": "bunker@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+                      "dependencies": {
+                        "burrito": {
+                          "version": "0.2.12",
+                          "from": "burrito@>=0.2.5 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+                          "dependencies": {
+                            "traverse": {
+                              "version": "0.5.2",
+                              "from": "traverse@>=0.5.1 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
+                            },
+                            "uglify-js": {
+                              "version": "1.1.1",
+                              "from": "uglify-js@>=1.1.1 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "slide": {
+                  "version": "1.1.6",
+                  "from": "slide@*",
+                  "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+                },
+                "yamlish": {
+                  "version": "0.0.6",
+                  "from": "yamlish@*",
+                  "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.6.tgz"
+                }
+              }
+            },
+            "xml-escape": {
+              "version": "1.0.0",
+              "from": "xml-escape@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.6",
+          "from": "through@>=2.3.6 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+        },
+        "tiny-lr": {
+          "version": "0.1.5",
+          "from": "tiny-lr@0.1.5",
+          "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.1.5.tgz",
+          "dependencies": {
+            "body-parser": {
+              "version": "1.8.4",
+              "from": "body-parser@>=1.8.0 <1.9.0",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
+              "dependencies": {
+                "bytes": {
+                  "version": "1.0.0",
+                  "from": "bytes@1.0.0",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+                },
+                "depd": {
+                  "version": "0.4.5",
+                  "from": "depd@0.4.5",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+                },
+                "iconv-lite": {
+                  "version": "0.4.4",
+                  "from": "iconv-lite@0.4.4",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                },
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "from": "on-finished@2.1.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "from": "ee-first@1.0.5",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                    }
+                  }
+                },
+                "qs": {
+                  "version": "2.2.4",
+                  "from": "qs@2.2.4",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
+                },
+                "raw-body": {
+                  "version": "1.3.0",
+                  "from": "raw-body@1.3.0",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+                },
+                "type-is": {
+                  "version": "1.5.7",
+                  "from": "type-is@>=1.5.1 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.10",
+                      "from": "mime-types@>=2.0.10 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.8.0",
+                          "from": "mime-db@>=1.8.0 <1.9.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.7.3",
+              "from": "faye-websocket@>=0.7.2 <0.8.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.5.4",
+                  "from": "websocket-driver@>=0.3.6",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.4.tgz",
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "websocket-extensions@>=0.1.1",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "livereload-js": {
+              "version": "2.2.2",
+              "from": "livereload-js@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "qs": {
+              "version": "2.2.5",
+              "from": "qs@>=2.2.3 <2.3.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz"
+            }
+          }
+        },
+        "walk-sync": {
+          "version": "0.1.3",
+          "from": "walk-sync@0.1.3",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+        },
+        "yam": {
+          "version": "0.0.18",
+          "from": "yam@0.0.18",
+          "resolved": "https://registry.npmjs.org/yam/-/yam-0.0.18.tgz",
+          "dependencies": {
+            "findup": {
+              "version": "0.1.5",
+              "from": "findup@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+              "dependencies": {
+                "colors": {
+                  "version": "0.6.2",
+                  "from": "colors@>=0.6.0-1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+                },
+                "commander": {
+                  "version": "2.1.0",
+                  "from": "commander@>=2.1.0 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+                }
+              }
+            },
+            "fs-extra": {
+              "version": "0.16.5",
+              "from": "fs-extra@>=0.16.3 <0.17.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.6",
+                  "from": "graceful-fs@>=3.0.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                },
+                "jsonfile": {
+                  "version": "2.0.0",
+                  "from": "jsonfile@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
+                }
+              }
+            },
+            "lodash.merge": {
+              "version": "3.1.0",
+              "from": "lodash.merge@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.1.0.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                },
+                "lodash._basefor": {
+                  "version": "3.0.1",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.1.tgz"
+                },
+                "lodash._createassigner": {
+                  "version": "3.0.1",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.0.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.0",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.0.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.5",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.5.tgz"
+                    }
+                  }
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.1",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.1",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.1.tgz"
+                },
+                "lodash.isnative": {
+                  "version": "3.0.1",
+                  "from": "lodash.isnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.1.tgz"
+                },
+                "lodash.isplainobject": {
+                  "version": "3.0.1",
+                  "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.0.1.tgz"
+                },
+                "lodash.istypedarray": {
+                  "version": "3.0.1",
+                  "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.5",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.5.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "3.0.4",
+                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.4.tgz"
+                },
+                "lodash.toplainobject": {
+                  "version": "3.0.0",
+                  "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.0",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-app-version": {
+      "version": "0.3.3",
+      "from": "ember-cli-app-version@0.3.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-0.3.3.tgz",
+      "dependencies": {
+        "git-repo-version": {
+          "version": "0.2.0",
+          "from": "git-repo-version@0.2.0",
+          "resolved": "https://registry.npmjs.org/git-repo-version/-/git-repo-version-0.2.0.tgz",
+          "dependencies": {
+            "git-repo-info": {
+              "version": "1.0.4",
+              "from": "git-repo-info@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.0.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-babel": {
+      "version": "4.3.3",
+      "from": "ember-cli-babel@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-4.3.3.tgz",
+      "dependencies": {
+        "broccoli-babel-transpiler": {
+          "version": "4.1.0",
+          "from": "broccoli-babel-transpiler@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-4.1.0.tgz",
+          "dependencies": {
+            "babel-core": {
+              "version": "4.7.16",
+              "from": "babel-core@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-4.7.16.tgz",
+              "dependencies": {
+                "acorn-babel": {
+                  "version": "0.11.1-38",
+                  "from": "acorn-babel@0.11.1-38",
+                  "resolved": "https://registry.npmjs.org/acorn-babel/-/acorn-babel-0.11.1-38.tgz"
+                },
+                "ast-types": {
+                  "version": "0.7.2",
+                  "from": "ast-types@>=0.7.0 <0.8.0",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.2.tgz"
+                },
+                "chalk": {
+                  "version": "1.0.0",
+                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.0.1",
+                      "from": "ansi-styles@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "1.0.3",
+                      "from": "has-ansi@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        },
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "2.0.1",
+                      "from": "strip-ansi@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "1.1.1",
+                          "from": "ansi-regex@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "1.3.1",
+                      "from": "supports-color@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.7.1",
+                  "from": "commander@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "0.5.1",
+                  "from": "convert-source-map@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.5.1.tgz"
+                },
+                "core-js": {
+                  "version": "0.6.1",
+                  "from": "core-js@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.6.1.tgz"
+                },
+                "debug": {
+                  "version": "2.1.3",
+                  "from": "debug@>=2.1.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.0",
+                      "from": "ms@0.7.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                    }
+                  }
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "from": "detect-indent@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    }
+                  }
+                },
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                },
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.1",
+                  "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.1.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "from": "globals@>=6.2.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                },
+                "is-integer": {
+                  "version": "1.0.4",
+                  "from": "is-integer@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.0",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                    },
+                    "is-nan": {
+                      "version": "1.0.1",
+                      "from": "is-nan@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.0.1.tgz"
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.0",
+                  "from": "js-tokens@1.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.0.tgz"
+                },
+                "leven": {
+                  "version": "1.0.1",
+                  "from": "leven@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.1.tgz"
+                },
+                "line-numbers": {
+                  "version": "0.2.0",
+                  "from": "line-numbers@0.2.0",
+                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                  "dependencies": {
+                    "left-pad": {
+                      "version": "0.0.3",
+                      "from": "left-pad@0.0.3",
+                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.6.0",
+                  "from": "lodash@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                },
+                "output-file-sync": {
+                  "version": "1.1.0",
+                  "from": "output-file-sync@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.0.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.0",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "private@>=0.1.6 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "regenerator-babel": {
+                  "version": "0.8.13-2",
+                  "from": "regenerator-babel@0.8.13-2",
+                  "resolved": "https://registry.npmjs.org/regenerator-babel/-/regenerator-babel-0.8.13-2.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.1",
+                      "from": "commoner@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
+                      "dependencies": {
+                        "q": {
+                          "version": "1.1.2",
+                          "from": "q@>=1.1.2 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                        },
+                        "recast": {
+                          "version": "0.9.18",
+                          "from": "recast@>=0.9.5 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
+                          "dependencies": {
+                            "esprima-fb": {
+                              "version": "10001.1.0-dev-harmony-fb",
+                              "from": "esprima-fb@>=10001.1.0-dev-harmony-fb <10001.2.0",
+                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
+                            },
+                            "source-map": {
+                              "version": "0.1.43",
+                              "from": "source-map@>=0.1.40 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                              "dependencies": {
+                                "amdefine": {
+                                  "version": "0.1.0",
+                                  "from": "amdefine@>=0.0.4",
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                                }
+                              }
+                            },
+                            "ast-types": {
+                              "version": "0.6.16",
+                              "from": "ast-types@>=0.6.1 <0.7.0",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz"
+                            }
+                          }
+                        },
+                        "commander": {
+                          "version": "2.5.1",
+                          "from": "commander@>=2.5.0 <2.6.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                        },
+                        "graceful-fs": {
+                          "version": "3.0.6",
+                          "from": "graceful-fs@>=3.0.4 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                        },
+                        "glob": {
+                          "version": "4.2.2",
+                          "from": "glob@>=4.2.1 <4.3.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "1.0.0",
+                              "from": "minimatch@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.5.0",
+                                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.0",
+                                  "from": "sigmund@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.1",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "install": {
+                          "version": "0.1.8",
+                          "from": "install@>=0.1.7 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.7",
+                          "from": "iconv-lite@>=0.4.5 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.6",
+                      "from": "through@>=2.3.6 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.1.2",
+                  "from": "regexpu@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.1.2.tgz",
+                  "dependencies": {
+                    "recast": {
+                      "version": "0.10.11",
+                      "from": "recast@>=0.10.1 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.11.tgz",
+                      "dependencies": {
+                        "esprima-fb": {
+                          "version": "13001.1001.0-dev-harmony-fb",
+                          "from": "esprima-fb@>=13001.1001.0-dev-harmony-fb <13001.1002.0",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.2.1",
+                      "from": "regenerate@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "regjsgen@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.4",
+                      "from": "regjsparser@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "jsesc@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.2",
+                  "from": "repeating@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.0",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                    },
+                    "meow": {
+                      "version": "3.1.0",
+                      "from": "meow@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.0.2",
+                              "from": "camelcase@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.0",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.1",
+                          "from": "indent-string@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.1.1",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                        },
+                        "object-assign": {
+                          "version": "2.0.0",
+                          "from": "object-assign@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "from": "shebang-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "slash": {
+                  "version": "1.0.0",
+                  "from": "slash@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.2",
+                  "from": "source-map@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "from": "source-map-support@>=0.2.9 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "from": "source-map@0.1.32",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.0",
+                  "from": "trim-right@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.0.tgz"
+                }
+              }
+            },
+            "clone": {
+              "version": "0.2.0",
+              "from": "clone@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            }
+          }
+        },
+        "broccoli-filter": {
+          "version": "0.1.12",
+          "from": "broccoli-filter@>=0.1.6 <0.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.12.tgz",
+          "dependencies": {
+            "quick-temp": {
+              "version": "0.1.2",
+              "from": "quick-temp@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.6 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "mktemp@>=0.3.4 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@>=2.3.3 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.6 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            },
+            "broccoli-writer": {
+              "version": "0.1.1",
+              "from": "broccoli-writer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz"
+            },
+            "walk-sync": {
+              "version": "0.1.3",
+              "from": "walk-sync@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+            },
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.6",
+              "from": "broccoli-kitchen-sink-helpers@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.0.4",
+                  "from": "glob@4.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "promise-map-series": {
+              "version": "0.2.1",
+              "from": "promise-map-series@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.1.tgz"
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.0.2",
+          "from": "ember-cli-version-checker@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.0.2.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.3",
+              "from": "semver@>=4.2.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-content-security-policy": {
+      "version": "0.4.0",
+      "from": "ember-cli-content-security-policy@0.4.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-content-security-policy/-/ember-cli-content-security-policy-0.4.0.tgz",
+      "dependencies": {
+        "body-parser": {
+          "version": "1.12.2",
+          "from": "body-parser@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.2.tgz",
+          "dependencies": {
+            "bytes": {
+              "version": "1.0.0",
+              "from": "bytes@1.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+            },
+            "content-type": {
+              "version": "1.0.1",
+              "from": "content-type@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+            },
+            "debug": {
+              "version": "2.1.3",
+              "from": "debug@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.0.0",
+              "from": "depd@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+            },
+            "iconv-lite": {
+              "version": "0.4.7",
+              "from": "iconv-lite@0.4.7",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
+            },
+            "on-finished": {
+              "version": "2.2.0",
+              "from": "on-finished@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "from": "ee-first@1.1.0",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "2.4.1",
+              "from": "qs@2.4.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.1.tgz"
+            },
+            "raw-body": {
+              "version": "1.3.3",
+              "from": "raw-body@1.3.3",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.3.tgz"
+            },
+            "type-is": {
+              "version": "1.6.1",
+              "from": "type-is@>=1.6.1 <1.7.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.10",
+                  "from": "mime-types@>=2.0.10 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.10.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "from": "mime-db@>=1.8.0 <1.9.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.8.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-dependency-checker": {
+      "version": "0.0.8",
+      "from": "ember-cli-dependency-checker@0.0.8",
+      "resolved": "https://registry.npmjs.org/ember-cli-dependency-checker/-/ember-cli-dependency-checker-0.0.8.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "semver": {
+          "version": "4.3.3",
+          "from": "semver@>=4.2.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+        }
+      }
+    },
+    "ember-cli-htmlbars": {
+      "version": "0.7.4",
+      "from": "ember-cli-htmlbars@0.7.4",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-0.7.4.tgz",
+      "dependencies": {
+        "broccoli-filter": {
+          "version": "0.1.12",
+          "from": "broccoli-filter@>=0.1.6 <0.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.12.tgz",
+          "dependencies": {
+            "quick-temp": {
+              "version": "0.1.2",
+              "from": "quick-temp@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.6 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "mktemp": {
+                  "version": "0.3.5",
+                  "from": "mktemp@>=0.3.4 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@>=2.3.3 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.6 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            },
+            "broccoli-writer": {
+              "version": "0.1.1",
+              "from": "broccoli-writer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz"
+            },
+            "walk-sync": {
+              "version": "0.1.3",
+              "from": "walk-sync@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+            },
+            "broccoli-kitchen-sink-helpers": {
+              "version": "0.2.6",
+              "from": "broccoli-kitchen-sink-helpers@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.0.4",
+                  "from": "glob@4.0.4",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "promise-map-series": {
+              "version": "0.2.1",
+              "from": "promise-map-series@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.1.tgz"
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.0.2",
+          "from": "ember-cli-version-checker@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.0.2.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.3",
+              "from": "semver@>=4.2.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-ic-ajax": {
+      "version": "0.1.1",
+      "from": "ember-cli-ic-ajax@0.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-ic-ajax/-/ember-cli-ic-ajax-0.1.1.tgz",
+      "dependencies": {
+        "ic-ajax": {
+          "version": "2.0.2",
+          "from": "ic-ajax@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/ic-ajax/-/ic-ajax-2.0.2.tgz"
+        }
+      }
+    },
+    "ember-cli-inject-live-reload": {
+      "version": "1.3.1",
+      "from": "ember-cli-inject-live-reload@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.3.1.tgz"
+    },
+    "ember-cli-materialize": {
+      "version": "0.5.2",
+      "from": "ember-cli-materialize@>=0.5.2 <0.6.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-materialize/-/ember-cli-materialize-0.5.2.tgz"
+    },
+    "ember-cli-node-webkit": {
+      "version": "0.2.0",
+      "from": "ember-cli-node-webkit@0.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-node-webkit/-/ember-cli-node-webkit-0.2.0.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "node-webkit-builder": {
+          "version": "1.0.11",
+          "from": "node-webkit-builder@>=1.0.11 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-webkit-builder/-/node-webkit-builder-1.0.11.tgz",
+          "dependencies": {
+            "archiver": {
+              "version": "0.13.1",
+              "from": "archiver@>=0.13.0 <0.14.0",
+              "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.13.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                },
+                "buffer-crc32": {
+                  "version": "0.2.5",
+                  "from": "buffer-crc32@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
+                },
+                "glob": {
+                  "version": "4.3.5",
+                  "from": "glob@>=4.3.0 <4.4.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lazystream": {
+                  "version": "0.1.0",
+                  "from": "lazystream@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "tar-stream": {
+                  "version": "1.1.2",
+                  "from": "tar-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.2.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "from": "bl@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                    },
+                    "end-of-stream": {
+                      "version": "1.1.0",
+                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <4.1.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "zip-stream": {
+                  "version": "0.5.1",
+                  "from": "zip-stream@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.1.tgz",
+                  "dependencies": {
+                    "compress-commons": {
+                      "version": "0.2.8",
+                      "from": "compress-commons@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.8.tgz",
+                      "dependencies": {
+                        "crc32-stream": {
+                          "version": "0.3.3",
+                          "from": "crc32-stream@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.3.tgz"
+                        },
+                        "node-int64": {
+                          "version": "0.3.3",
+                          "from": "node-int64@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "3.2.0",
+                      "from": "lodash@>=3.2.0 <3.3.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "bluebird": {
+              "version": "1.2.4",
+              "from": "bluebird@>=1.2.2 <1.3.0",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz"
+            },
+            "decompress-zip": {
+              "version": "0.0.8",
+              "from": "decompress-zip@0.0.8",
+              "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.0.8.tgz",
+              "dependencies": {
+                "q": {
+                  "version": "1.0.1",
+                  "from": "q@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+                },
+                "mkpath": {
+                  "version": "0.1.0",
+                  "from": "mkpath@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+                },
+                "binary": {
+                  "version": "0.3.0",
+                  "from": "binary@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+                  "dependencies": {
+                    "chainsaw": {
+                      "version": "0.1.0",
+                      "from": "chainsaw@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                      "dependencies": {
+                        "traverse": {
+                          "version": "0.3.9",
+                          "from": "traverse@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                        }
+                      }
+                    },
+                    "buffers": {
+                      "version": "0.1.1",
+                      "from": "buffers@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                    }
+                  }
+                },
+                "touch": {
+                  "version": "0.0.2",
+                  "from": "touch@0.0.2",
+                  "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.2.tgz",
+                  "dependencies": {
+                    "nopt": {
+                      "version": "1.0.10",
+                      "from": "nopt@>=1.0.10 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.5",
+                          "from": "abbrev@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "2.2.1",
+                  "from": "nopt@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.5",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.6",
+                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "rcedit": {
+              "version": "0.2.0",
+              "from": "rcedit@0.2.0",
+              "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-0.2.0.tgz"
+            },
+            "plist": {
+              "version": "1.1.0",
+              "from": "plist@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/plist/-/plist-1.1.0.tgz",
+              "dependencies": {
+                "base64-js": {
+                  "version": "0.0.6",
+                  "from": "base64-js@0.0.6",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz"
+                },
+                "xmlbuilder": {
+                  "version": "2.2.1",
+                  "from": "xmlbuilder@2.2.1",
+                  "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
+                  "dependencies": {
+                    "lodash-node": {
+                      "version": "2.4.1",
+                      "from": "lodash-node@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+                    }
+                  }
+                },
+                "xmldom": {
+                  "version": "0.1.19",
+                  "from": "xmldom@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.0",
+                  "from": "util-deprecate@1.0.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.0.tgz"
+                }
+              }
+            },
+            "progress": {
+              "version": "1.1.8",
+              "from": "progress@>=1.1.7 <1.2.0",
+              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+            },
+            "request": {
+              "version": "2.40.0",
+              "from": "request@>=2.40.0 <2.41.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+              "dependencies": {
+                "qs": {
+                  "version": "1.0.2",
+                  "from": "qs@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@>=1.2.11 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "async": {
+                      "version": "0.9.0",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.3.2",
+              "from": "rimraf@>=2.2.8 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.4.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "2.3.2",
+              "from": "semver@>=2.3.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+            },
+            "simple-glob": {
+              "version": "0.1.0",
+              "from": "simple-glob@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.0.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.8 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.14 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "tar-fs": {
+              "version": "0.3.3",
+              "from": "tar-fs@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-0.3.3.tgz",
+              "dependencies": {
+                "tar-stream": {
+                  "version": "0.4.7",
+                  "from": "tar-stream@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "from": "bl@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                    },
+                    "end-of-stream": {
+                      "version": "1.1.0",
+                      "from": "end-of-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "pump": {
+                  "version": "0.3.5",
+                  "from": "pump@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/pump/-/pump-0.3.5.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.2.0",
+                      "from": "once@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.2.0.tgz"
+                    },
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "from": "end-of-stream@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                }
+              }
+            },
+            "temp": {
+              "version": "0.7.0",
+              "from": "temp@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/temp/-/temp-0.7.0.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.6 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                }
+              }
+            },
+            "update-notifier": {
+              "version": "0.1.10",
+              "from": "update-notifier@>=0.1.8 <0.2.0",
+              "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.1.10.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.4.0",
+                  "from": "chalk@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+                  "dependencies": {
+                    "has-color": {
+                      "version": "0.1.7",
+                      "from": "has-color@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "1.0.0",
+                      "from": "ansi-styles@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "0.1.1",
+                      "from": "strip-ansi@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                    }
+                  }
+                },
+                "configstore": {
+                  "version": "0.3.2",
+                  "from": "configstore@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "3.0.6",
+                      "from": "graceful-fs@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                    },
+                    "js-yaml": {
+                      "version": "3.2.7",
+                      "from": "js-yaml@>=3.1.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
+                      "dependencies": {
+                        "argparse": {
+                          "version": "1.0.2",
+                          "from": "argparse@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                          "dependencies": {
+                            "lodash": {
+                              "version": "3.6.0",
+                              "from": "lodash@>=3.2.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+                            },
+                            "sprintf-js": {
+                              "version": "1.0.2",
+                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "2.0.0",
+                          "from": "esprima@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.0",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "2.0.0",
+                      "from": "object-assign@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                    },
+                    "osenv": {
+                      "version": "0.1.0",
+                      "from": "osenv@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "from": "user-home@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    },
+                    "uuid": {
+                      "version": "2.0.1",
+                      "from": "uuid@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                    },
+                    "xdg-basedir": {
+                      "version": "1.0.1",
+                      "from": "xdg-basedir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "winresourcer": {
+              "version": "0.9.0",
+              "from": "winresourcer@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/winresourcer/-/winresourcer-0.9.0.tgz"
+            },
+            "platform-overrides": {
+              "version": "1.0.1",
+              "from": "platform-overrides@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/platform-overrides/-/platform-overrides-1.0.1.tgz"
+            },
+            "graceful-ncp": {
+              "version": "2.0.0",
+              "from": "graceful-ncp@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-ncp/-/graceful-ncp-2.0.0.tgz",
+              "dependencies": {
+                "proxyquire": {
+                  "version": "1.4.0",
+                  "from": "proxyquire@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.4.0.tgz"
+                },
+                "graceful-fs": {
+                  "version": "3.0.6",
+                  "from": "graceful-fs@>=3.0.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                },
+                "ncp": {
+                  "version": "2.0.0",
+                  "from": "ncp@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+                }
+              }
+            },
+            "graceful-fs-extra": {
+              "version": "1.0.6",
+              "from": "graceful-fs-extra@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs-extra/-/graceful-fs-extra-1.0.6.tgz",
+              "dependencies": {
+                "proxyquire": {
+                  "version": "1.4.0",
+                  "from": "proxyquire@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.4.0.tgz"
+                },
+                "fs-extra": {
+                  "version": "0.13.0",
+                  "from": "fs-extra@0.13.0",
+                  "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.13.0.tgz",
+                  "dependencies": {
+                    "ncp": {
+                      "version": "1.0.1",
+                      "from": "ncp@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz"
+                    },
+                    "jsonfile": {
+                      "version": "2.0.0",
+                      "from": "jsonfile@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.0.18",
+          "from": "rsvp@>=3.0.6 <3.1.0",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+        }
+      }
+    },
+    "ember-cli-qunit": {
+      "version": "0.3.9",
+      "from": "ember-cli-qunit@0.3.9",
+      "resolved": "https://registry.npmjs.org/ember-cli-qunit/-/ember-cli-qunit-0.3.9.tgz",
+      "dependencies": {
+        "broccoli-jshint": {
+          "version": "0.5.5",
+          "from": "broccoli-jshint@0.5.5",
+          "resolved": "https://registry.npmjs.org/broccoli-jshint/-/broccoli-jshint-0.5.5.tgz",
+          "dependencies": {
+            "jshint": {
+              "version": "2.6.3",
+              "from": "jshint@>=2.6.2 <2.7.0",
+              "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.6.3.tgz",
+              "dependencies": {
+                "cli": {
+                  "version": "0.6.6",
+                  "from": "cli@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "from": "glob@>=3.2.1 <3.3.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "from": "console-browserify@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "from": "date-now@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "from": "exit@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                },
+                "htmlparser2": {
+                  "version": "3.8.2",
+                  "from": "htmlparser2@>=3.8.0 <3.9.0",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+                  "dependencies": {
+                    "domhandler": {
+                      "version": "2.3.0",
+                      "from": "domhandler@>=2.3.0 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                    },
+                    "domutils": {
+                      "version": "1.5.1",
+                      "from": "domutils@>=1.5.0 <1.6.0",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "dependencies": {
+                        "dom-serializer": {
+                          "version": "0.1.0",
+                          "from": "dom-serializer@>=0.0.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.1.3",
+                              "from": "domelementtype@>=1.1.1 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                            },
+                            "entities": {
+                              "version": "1.1.1",
+                              "from": "entities@>=1.1.1 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "from": "entities@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "shelljs": {
+                  "version": "0.3.0",
+                  "from": "shelljs@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.2",
+                  "from": "strip-json-comments@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+                },
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "from": "chalk@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "has-color@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "ansi-styles@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "strip-ansi@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            },
+            "broccoli-filter": {
+              "version": "0.1.12",
+              "from": "broccoli-filter@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.12.tgz",
+              "dependencies": {
+                "quick-temp": {
+                  "version": "0.1.2",
+                  "from": "quick-temp@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "rimraf@>=2.2.6 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "mktemp@>=0.3.4 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@>=2.3.3 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "rsvp": {
+                  "version": "3.0.18",
+                  "from": "rsvp@>=3.0.16 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+                },
+                "broccoli-writer": {
+                  "version": "0.1.1",
+                  "from": "broccoli-writer@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz"
+                },
+                "walk-sync": {
+                  "version": "0.1.3",
+                  "from": "walk-sync@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+                },
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.2.6",
+                  "from": "broccoli-kitchen-sink-helpers@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.0.4",
+                      "from": "glob@4.0.4",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "3.0.6",
+                          "from": "graceful-fs@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "promise-map-series": {
+                  "version": "0.2.1",
+                  "from": "promise-map-series@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.1.tgz"
+                }
+              }
+            },
+            "findup-sync": {
+              "version": "0.1.3",
+              "from": "findup-sync@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.9 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.4.2",
+              "from": "mkdirp@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.4.2.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-sass": {
+      "version": "3.1.1",
+      "from": "ember-cli-sass@3.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-3.1.1.tgz",
+      "dependencies": {
+        "broccoli-sass-source-maps": {
+          "version": "0.6.3",
+          "from": "broccoli-sass-source-maps@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-0.6.3.tgz",
+          "dependencies": {
+            "broccoli-caching-writer": {
+              "version": "0.5.5",
+              "from": "broccoli-caching-writer@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-0.5.5.tgz",
+              "dependencies": {
+                "broccoli-kitchen-sink-helpers": {
+                  "version": "0.2.6",
+                  "from": "broccoli-kitchen-sink-helpers@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.0.4",
+                      "from": "glob@4.0.4",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "3.0.6",
+                          "from": "graceful-fs@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "core-object": {
+                  "version": "0.0.3",
+                  "from": "core-object@0.0.3",
+                  "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.3.tgz"
+                },
+                "debug": {
+                  "version": "2.1.3",
+                  "from": "debug@>=2.1.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.0",
+                      "from": "ms@0.7.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                    }
+                  }
+                },
+                "lodash-node": {
+                  "version": "2.4.1",
+                  "from": "lodash-node@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+                },
+                "promise-map-series": {
+                  "version": "0.2.1",
+                  "from": "promise-map-series@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.1.tgz"
+                },
+                "quick-temp": {
+                  "version": "0.1.2",
+                  "from": "quick-temp@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "rimraf@>=2.2.6 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "mktemp@>=0.3.4 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@>=2.3.3 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.3.2",
+                  "from": "rimraf@>=2.2.8 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.4.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "2.0.4",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "symlink-or-copy": {
+                  "version": "1.0.1",
+                  "from": "symlink-or-copy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+                  "dependencies": {
+                    "copy-dereference": {
+                      "version": "1.0.0",
+                      "from": "copy-dereference@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "include-path-searcher": {
+              "version": "0.1.0",
+              "from": "include-path-searcher@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/include-path-searcher/-/include-path-searcher-0.1.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "node-sass": {
+              "version": "3.0.0-alpha.0",
+              "from": "node-sass@3.0.0-alpha.0"
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.6 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.0.2",
+          "from": "ember-cli-version-checker@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.0.2.tgz",
+          "dependencies": {
+            "semver": {
+              "version": "4.3.3",
+              "from": "semver@>=4.2.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-uglify": {
+      "version": "1.0.1",
+      "from": "ember-cli-uglify@1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-1.0.1.tgz",
+      "dependencies": {
+        "broccoli-uglify-sourcemap": {
+          "version": "0.2.1",
+          "from": "broccoli-uglify-sourcemap@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-0.2.1.tgz",
+          "dependencies": {
+            "broccoli-writer": {
+              "version": "0.1.1",
+              "from": "broccoli-writer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+              "dependencies": {
+                "quick-temp": {
+                  "version": "0.1.2",
+                  "from": "quick-temp@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.2.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.2.8",
+                      "from": "rimraf@>=2.2.6 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                    },
+                    "mktemp": {
+                      "version": "0.3.5",
+                      "from": "mktemp@>=0.3.4 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.3.5.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.3",
+                      "from": "underscore.string@>=2.3.3 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                    }
+                  }
+                },
+                "rsvp": {
+                  "version": "3.0.18",
+                  "from": "rsvp@>=3.0.6 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "from": "lodash-node@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "source-map-url": {
+              "version": "0.3.0",
+              "from": "source-map-url@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+            },
+            "symlink-or-copy": {
+              "version": "1.0.1",
+              "from": "symlink-or-copy@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.0.1.tgz",
+              "dependencies": {
+                "copy-dereference": {
+                  "version": "1.0.0",
+                  "from": "copy-dereference@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.19",
+              "from": "uglify-js@>=2.4.16 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.19.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.0.2",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                }
+              }
+            },
+            "walk-sync": {
+              "version": "0.1.3",
+              "from": "walk-sync@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ember-data": {
+      "version": "1.0.0-beta.16.1",
+      "from": "ember-data@1.0.0-beta.16.1",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-1.0.0-beta.16.1.tgz"
+    },
+    "ember-export-application-global": {
+      "version": "1.0.2",
+      "from": "ember-export-application-global@1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-1.0.2.tgz"
+    },
+    "ember-localstorage-adapter": {
+      "version": "0.5.2",
+      "from": "../../../../var/folders/sp/ts6dl7k57lg3v13d9z4ffjp80000gn/T/npm-10636-ae60097f/git-cache-16493d7ac31e/2e4b6f482a09953cf12f774c4242b79c832fce6a",
+      "resolved": "git+https://github.com/kurko/ember-localstorage-adapter#2e4b6f482a09953cf12f774c4242b79c832fce6a"
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "from": "grunt@>=0.4.5 <0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "dateformat@1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.12 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.6 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.1",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.10.0",
+      "from": "grunt-contrib-jshint@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
+      "dependencies": {
+        "jshint": {
+          "version": "2.5.11",
+          "from": "jshint@>=2.5.0 <2.6.0",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
+          "dependencies": {
+            "cli": {
+              "version": "0.6.6",
+              "from": "cli@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.1 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            },
+            "htmlparser2": {
+              "version": "3.8.2",
+              "from": "htmlparser2@>=3.8.0 <3.9.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.3.0",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "from": "entities@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "from": "shelljs@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.2",
+              "from": "strip-json-comments@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+            },
+            "underscore": {
+              "version": "1.6.0",
+              "from": "underscore@>=1.6.0 <1.7.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        }
+      }
+    },
+    "grunt-js-beautify": {
+      "version": "0.1.2",
+      "from": "grunt-js-beautify@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-js-beautify/-/grunt-js-beautify-0.1.2.tgz",
+      "dependencies": {
+        "js-beautify": {
+          "version": "1.5.5",
+          "from": "js-beautify@>=1.5.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.5.tgz",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.8",
+              "from": "config-chain@>=1.1.5 <1.2.0",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.3",
+                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                },
+                "ini": {
+                  "version": "1.3.3",
+                  "from": "ini@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@>=3.0.1 <3.1.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-jscodesniffer": {
+      "version": "0.1.10",
+      "from": "grunt-jscodesniffer@>=0.1.8 <0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-jscodesniffer/-/grunt-jscodesniffer-0.1.10.tgz",
+      "dependencies": {
+        "jscodesniffer": {
+          "version": "2.2.0",
+          "from": "jscodesniffer@>=2.0.3",
+          "resolved": "https://registry.npmjs.org/jscodesniffer/-/jscodesniffer-2.2.0.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            },
+            "glob": {
+              "version": "5.0.3",
+              "from": "glob@>=5.0.1 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "minimatch@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-jscs": {
+      "version": "0.8.1",
+      "from": "grunt-jscs@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-0.8.1.tgz",
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "jscs": {
+          "version": "1.7.3",
+          "from": "jscs@>=1.7.2 <1.8.0",
+          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.7.3.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "from": "colors@>=0.6.2 <0.7.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+            },
+            "commander": {
+              "version": "2.3.0",
+              "from": "commander@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+            },
+            "esprima": {
+              "version": "1.2.5",
+              "from": "esprima@>=1.2.2 <1.3.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "esprima-harmony-jscs": {
+              "version": "1.1.0-dev-harmony",
+              "from": "esprima-harmony-jscs@1.1.0-dev-harmony",
+              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-dev-harmony.tgz"
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            },
+            "glob": {
+              "version": "4.0.6",
+              "from": "glob@>=4.0.0 <4.1.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.6",
+                  "from": "graceful-fs@>=3.0.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "strip-json-comments": {
+              "version": "1.0.2",
+              "from": "strip-json-comments@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+            },
+            "vow-fs": {
+              "version": "0.3.4",
+              "from": "vow-fs@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
+              "dependencies": {
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "vow-queue": {
+                  "version": "0.4.1",
+                  "from": "vow-queue@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.1.tgz"
+                },
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.3.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "xmlbuilder": {
+              "version": "2.4.6",
+              "from": "xmlbuilder@>=2.4.0 <2.5.0",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.4.6.tgz",
+              "dependencies": {
+                "lodash-node": {
+                  "version": "2.4.1",
+                  "from": "lodash-node@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.1.0",
+              "from": "supports-color@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.1.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+        },
+        "vow": {
+          "version": "0.4.9",
+          "from": "vow@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.9.tgz"
+        }
+      }
+    },
+    "load-grunt-tasks": {
+      "version": "1.0.0",
+      "from": "load-grunt-tasks@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-1.0.0.tgz",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+            }
+          }
+        },
+        "multimatch": {
+          "version": "1.0.1",
+          "from": "multimatch@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-1.0.1.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "from": "memorystream@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz"
+    },
+    "nw": {
+      "version": "0.12.0",
+      "from": "nw@0.12.0",
+      "resolved": "https://registry.npmjs.org/nw/-/nw-0.12.0.tgz",
+      "dependencies": {
+        "download": {
+          "version": "4.1.2",
+          "from": "download@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/download/-/download-4.1.2.tgz",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.4.7",
+              "from": "concat-stream@>=1.4.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.7.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "each-async": {
+              "version": "1.1.1",
+              "from": "each-async@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+              "dependencies": {
+                "onetime": {
+                  "version": "1.0.0",
+                  "from": "onetime@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                }
+              }
+            },
+            "filenamify": {
+              "version": "1.1.0",
+              "from": "filenamify@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.1.0.tgz",
+              "dependencies": {
+                "filename-reserved-regex": {
+                  "version": "1.0.0",
+                  "from": "filename-reserved-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                },
+                "strip-outer": {
+                  "version": "1.0.0",
+                  "from": "strip-outer@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    }
+                  }
+                },
+                "trim-repeated": {
+                  "version": "1.0.0",
+                  "from": "trim-repeated@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "got": {
+              "version": "2.5.0",
+              "from": "got@>=2.3.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-2.5.0.tgz",
+              "dependencies": {
+                "duplexify": {
+                  "version": "3.2.0",
+                  "from": "duplexify@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "from": "end-of-stream@1.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "infinity-agent": {
+                  "version": "1.0.2",
+                  "from": "infinity-agent@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-1.0.2.tgz"
+                },
+                "is-stream": {
+                  "version": "1.0.1",
+                  "from": "is-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                },
+                "lowercase-keys": {
+                  "version": "1.0.0",
+                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                },
+                "prepend-http": {
+                  "version": "1.0.1",
+                  "from": "prepend-http@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                },
+                "timed-out": {
+                  "version": "2.0.0",
+                  "from": "timed-out@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                }
+              }
+            },
+            "gulp-decompress": {
+              "version": "1.0.2",
+              "from": "gulp-decompress@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.0.2.tgz",
+              "dependencies": {
+                "archive-type": {
+                  "version": "2.0.0",
+                  "from": "archive-type@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-2.0.0.tgz",
+                  "dependencies": {
+                    "file-type": {
+                      "version": "2.5.0",
+                      "from": "file-type@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.5.0.tgz",
+                      "dependencies": {
+                        "meow": {
+                          "version": "3.1.0",
+                          "from": "meow@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                          "dependencies": {
+                            "camelcase-keys": {
+                              "version": "1.0.0",
+                              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                              "dependencies": {
+                                "camelcase": {
+                                  "version": "1.0.2",
+                                  "from": "camelcase@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                                },
+                                "map-obj": {
+                                  "version": "1.0.0",
+                                  "from": "map-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "indent-string": {
+                              "version": "1.2.1",
+                              "from": "indent-string@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                              "dependencies": {
+                                "get-stdin": {
+                                  "version": "4.0.1",
+                                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                },
+                                "repeating": {
+                                  "version": "1.1.2",
+                                  "from": "repeating@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.0",
+                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "get-stdin": {
+                      "version": "3.0.2",
+                      "from": "get-stdin@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                    },
+                    "meow": {
+                      "version": "2.1.0",
+                      "from": "meow@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.0.2",
+                              "from": "camelcase@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.0",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.1",
+                          "from": "indent-string@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            },
+                            "repeating": {
+                              "version": "1.1.2",
+                              "from": "repeating@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.0",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                                },
+                                "meow": {
+                                  "version": "3.1.0",
+                                  "from": "meow@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.1.1",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "read-chunk": {
+                      "version": "1.0.1",
+                      "from": "read-chunk@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+                    }
+                  }
+                },
+                "decompress": {
+                  "version": "2.2.1",
+                  "from": "decompress@>=2.1.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.2.1.tgz",
+                  "dependencies": {
+                    "buffer-to-vinyl": {
+                      "version": "1.0.0",
+                      "from": "buffer-to-vinyl@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.0.0.tgz",
+                      "dependencies": {
+                        "file-type": {
+                          "version": "2.5.0",
+                          "from": "file-type@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.5.0.tgz"
+                        },
+                        "uuid": {
+                          "version": "2.0.1",
+                          "from": "uuid@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "decompress-tar": {
+                      "version": "3.1.0",
+                      "from": "decompress-tar@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                      "dependencies": {
+                        "is-tar": {
+                          "version": "1.0.0",
+                          "from": "is-tar@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.0.0",
+                              "from": "chalk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "from": "supports-color@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                }
+                              }
+                            },
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "sum-up@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-stream": {
+                          "version": "1.1.2",
+                          "from": "tar-stream@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.2.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.4",
+                              "from": "bl@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                            },
+                            "end-of-stream": {
+                              "version": "1.1.0",
+                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.1",
+                                  "from": "once@>=1.3.0 <1.4.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.33 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "xtend@>=4.0.0 <4.1.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "decompress-tarbz2": {
+                      "version": "3.1.0",
+                      "from": "decompress-tarbz2@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                      "dependencies": {
+                        "is-bzip2": {
+                          "version": "1.0.0",
+                          "from": "is-bzip2@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                        },
+                        "seek-bzip": {
+                          "version": "1.0.4",
+                          "from": "seek-bzip@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.4.tgz",
+                          "dependencies": {
+                            "commander": {
+                              "version": "2.4.0",
+                              "from": "commander@>=2.4.0 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.4.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.0.0",
+                              "from": "chalk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "from": "supports-color@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                }
+                              }
+                            },
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "sum-up@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-stream": {
+                          "version": "1.1.2",
+                          "from": "tar-stream@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.2.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.4",
+                              "from": "bl@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                            },
+                            "end-of-stream": {
+                              "version": "1.1.0",
+                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.1",
+                                  "from": "once@>=1.3.0 <1.4.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.33 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "xtend@>=4.0.0 <4.1.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "decompress-targz": {
+                      "version": "3.1.0",
+                      "from": "decompress-targz@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                      "dependencies": {
+                        "is-gzip": {
+                          "version": "1.0.0",
+                          "from": "is-gzip@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.0.0",
+                              "from": "chalk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "from": "supports-color@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                }
+                              }
+                            },
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "sum-up@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-stream": {
+                          "version": "1.1.2",
+                          "from": "tar-stream@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.2.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.4",
+                              "from": "bl@>=0.9.0 <0.10.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                            },
+                            "end-of-stream": {
+                              "version": "1.1.0",
+                              "from": "end-of-stream@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.1",
+                                  "from": "once@>=1.3.0 <1.4.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.33 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "xtend@>=4.0.0 <4.1.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "decompress-unzip": {
+                      "version": "3.1.0",
+                      "from": "decompress-unzip@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.1.0.tgz",
+                      "dependencies": {
+                        "is-zip": {
+                          "version": "1.0.0",
+                          "from": "is-zip@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "strip-dirs@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.0.0",
+                              "from": "chalk@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.0.1",
+                                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "1.0.3",
+                                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "2.0.1",
+                                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "1.1.1",
+                                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "1.3.1",
+                                  "from": "supports-color@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                                }
+                              }
+                            },
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "is-absolute@>=0.1.5 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "is-natural-number@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "minimist@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "sum-up@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "yauzl": {
+                          "version": "2.2.1",
+                          "from": "yauzl@>=2.2.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.2.1.tgz",
+                          "dependencies": {
+                            "fd-slicer": {
+                              "version": "1.0.1",
+                              "from": "fd-slicer@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                            },
+                            "pend": {
+                              "version": "1.2.0",
+                              "from": "pend@>=1.2.0 <1.3.0",
+                              "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "vinyl-assign": {
+                      "version": "1.1.0",
+                      "from": "vinyl-assign@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.1.0.tgz"
+                    },
+                    "vinyl-fs": {
+                      "version": "0.3.13",
+                      "from": "vinyl-fs@>=0.3.7 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
+                      "dependencies": {
+                        "defaults": {
+                          "version": "1.0.2",
+                          "from": "defaults@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.2.tgz",
+                          "dependencies": {
+                            "clone": {
+                              "version": "0.1.19",
+                              "from": "clone@>=0.1.5 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+                            }
+                          }
+                        },
+                        "glob-stream": {
+                          "version": "3.1.18",
+                          "from": "glob-stream@>=3.1.5 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "4.5.3",
+                              "from": "glob@>=4.3.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "once": {
+                                  "version": "1.3.1",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "minimatch": {
+                              "version": "2.0.4",
+                              "from": "minimatch@>=2.0.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.0",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.0",
+                                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "ordered-read-streams": {
+                              "version": "0.1.0",
+                              "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                            },
+                            "glob2base": {
+                              "version": "0.0.12",
+                              "from": "glob2base@>=0.0.12 <0.0.13",
+                              "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                              "dependencies": {
+                                "find-index": {
+                                  "version": "0.1.1",
+                                  "from": "find-index@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                                }
+                              }
+                            },
+                            "unique-stream": {
+                              "version": "1.0.0",
+                              "from": "unique-stream@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "glob-watcher": {
+                          "version": "0.0.6",
+                          "from": "glob-watcher@>=0.0.6 <0.0.7",
+                          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+                          "dependencies": {
+                            "gaze": {
+                              "version": "0.5.1",
+                              "from": "gaze@>=0.5.1 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                              "dependencies": {
+                                "globule": {
+                                  "version": "0.1.0",
+                                  "from": "globule@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                                  "dependencies": {
+                                    "lodash": {
+                                      "version": "1.0.2",
+                                      "from": "lodash@>=1.0.1 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                                    },
+                                    "glob": {
+                                      "version": "3.1.21",
+                                      "from": "glob@>=3.1.21 <3.2.0",
+                                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "1.2.3",
+                                          "from": "graceful-fs@>=1.2.0 <1.3.0",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                        },
+                                        "inherits": {
+                                          "version": "1.0.0",
+                                          "from": "inherits@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "minimatch": {
+                                      "version": "0.2.14",
+                                      "from": "minimatch@>=0.2.11 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                      "dependencies": {
+                                        "lru-cache": {
+                                          "version": "2.5.0",
+                                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                        },
+                                        "sigmund": {
+                                          "version": "1.0.0",
+                                          "from": "sigmund@>=1.0.0 <1.1.0",
+                                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "3.0.6",
+                          "from": "graceful-fs@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "1.0.0",
+                          "from": "strip-bom@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                          "dependencies": {
+                            "first-chunk-stream": {
+                              "version": "1.0.0",
+                              "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                            },
+                            "is-utf8": {
+                              "version": "0.2.0",
+                              "from": "is-utf8@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "gulp-util": {
+                  "version": "3.0.4",
+                  "from": "gulp-util@>=3.0.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
+                  "dependencies": {
+                    "array-differ": {
+                      "version": "1.0.0",
+                      "from": "array-differ@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                    },
+                    "array-uniq": {
+                      "version": "1.0.2",
+                      "from": "array-uniq@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                    },
+                    "beeper": {
+                      "version": "1.0.0",
+                      "from": "beeper@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.0.0",
+                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.0.1",
+                          "from": "ansi-styles@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "1.0.3",
+                          "from": "has-ansi@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "2.0.1",
+                          "from": "strip-ansi@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "1.3.1",
+                          "from": "supports-color@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "dateformat": {
+                      "version": "1.0.11",
+                      "from": "dateformat@>=1.0.11 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz"
+                    },
+                    "lodash._reescape": {
+                      "version": "3.0.0",
+                      "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                    },
+                    "lodash._reevaluate": {
+                      "version": "3.0.0",
+                      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                    },
+                    "lodash._reinterpolate": {
+                      "version": "3.0.0",
+                      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                    },
+                    "lodash.template": {
+                      "version": "3.4.0",
+                      "from": "lodash.template@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.4.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.0",
+                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                        },
+                        "lodash._basetostring": {
+                          "version": "3.0.0",
+                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                        },
+                        "lodash._basevalues": {
+                          "version": "3.0.0",
+                          "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.5",
+                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.5.tgz"
+                        },
+                        "lodash.escape": {
+                          "version": "3.0.0",
+                          "from": "lodash.escape@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                        },
+                        "lodash.keys": {
+                          "version": "3.0.5",
+                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.0.5.tgz",
+                          "dependencies": {
+                            "lodash.isarguments": {
+                              "version": "3.0.1",
+                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.1.tgz"
+                            },
+                            "lodash.isarray": {
+                              "version": "3.0.1",
+                              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.1.tgz"
+                            },
+                            "lodash.isnative": {
+                              "version": "3.0.1",
+                              "from": "lodash.isnative@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isnative/-/lodash.isnative-3.0.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.0",
+                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.0.tgz"
+                        },
+                        "lodash.templatesettings": {
+                          "version": "3.1.0",
+                          "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    },
+                    "multipipe": {
+                      "version": "0.1.2",
+                      "from": "multipipe@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                      "dependencies": {
+                        "duplexer2": {
+                          "version": "0.0.2",
+                          "from": "duplexer2@0.0.2",
+                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "readable-stream@>=1.1.9 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "replace-ext": {
+                      "version": "0.0.1",
+                      "from": "replace-ext@0.0.1",
+                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "gulp-rename": {
+              "version": "1.2.0",
+              "from": "gulp-rename@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.0.tgz"
+            },
+            "is-url": {
+              "version": "1.2.0",
+              "from": "is-url@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.0.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.0.2",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.0",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.0",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "read-all-stream": {
+              "version": "1.0.2",
+              "from": "read-all-stream@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz"
+            },
+            "stream-combiner2": {
+              "version": "1.0.2",
+              "from": "stream-combiner2@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "through2@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@>=0.4.3 <0.5.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "vinyl-fs": {
+              "version": "1.0.0",
+              "from": "vinyl-fs@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
+              "dependencies": {
+                "duplexify": {
+                  "version": "3.2.0",
+                  "from": "duplexify@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz",
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "from": "end-of-stream@1.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob-stream": {
+                  "version": "4.1.1",
+                  "from": "glob-stream@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.4.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ordered-read-streams": {
+                      "version": "0.1.0",
+                      "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                    },
+                    "glob2base": {
+                      "version": "0.0.12",
+                      "from": "glob2base@>=0.0.12 <0.0.13",
+                      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                      "dependencies": {
+                        "find-index": {
+                          "version": "0.1.1",
+                          "from": "find-index@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "unique-stream": {
+                      "version": "2.0.2",
+                      "from": "unique-stream@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.0.2.tgz",
+                      "dependencies": {
+                        "es6-set": {
+                          "version": "0.1.1",
+                          "from": "es6-set@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                          "dependencies": {
+                            "d": {
+                              "version": "0.1.1",
+                              "from": "d@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                            },
+                            "es5-ext": {
+                              "version": "0.10.6",
+                              "from": "es5-ext@>=0.10.4 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+                              "dependencies": {
+                                "es6-symbol": {
+                                  "version": "2.0.1",
+                                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "from": "es6-iterator@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                              "dependencies": {
+                                "es6-symbol": {
+                                  "version": "2.0.1",
+                                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "es6-symbol": {
+                              "version": "0.1.1",
+                              "from": "es6-symbol@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                            },
+                            "event-emitter": {
+                              "version": "0.3.3",
+                              "from": "event-emitter@>=0.3.1 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                            }
+                          }
+                        },
+                        "through2-filter": {
+                          "version": "1.4.1",
+                          "from": "through2-filter@>=1.4.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-1.4.1.tgz",
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "xtend@>=4.0.0 <4.1.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob-watcher": {
+                  "version": "0.0.8",
+                  "from": "glob-watcher@>=0.0.8 <0.0.9",
+                  "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
+                  "dependencies": {
+                    "gaze": {
+                      "version": "0.5.1",
+                      "from": "gaze@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                      "dependencies": {
+                        "globule": {
+                          "version": "0.1.0",
+                          "from": "globule@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                          "dependencies": {
+                            "lodash": {
+                              "version": "1.0.2",
+                              "from": "lodash@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                            },
+                            "glob": {
+                              "version": "3.1.21",
+                              "from": "glob@>=3.1.21 <3.2.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "1.2.3",
+                                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                },
+                                "inherits": {
+                                  "version": "1.0.0",
+                                  "from": "inherits@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "minimatch": {
+                              "version": "0.2.14",
+                              "from": "minimatch@>=0.2.11 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.5.0",
+                                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.0",
+                                  "from": "sigmund@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.6",
+                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                },
+                "merge-stream": {
+                  "version": "0.1.7",
+                  "from": "merge-stream@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.7.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "strip-bom": {
+                  "version": "1.0.0",
+                  "from": "strip-bom@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                  "dependencies": {
+                    "first-chunk-stream": {
+                      "version": "1.0.0",
+                      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                    },
+                    "is-utf8": {
+                      "version": "0.2.0",
+                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ware": {
+              "version": "1.2.0",
+              "from": "ware@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ware/-/ware-1.2.0.tgz",
+              "dependencies": {
+                "wrap-fn": {
+                  "version": "0.1.4",
+                  "from": "wrap-fn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                  "dependencies": {
+                    "co": {
+                      "version": "3.1.0",
+                      "from": "co@3.1.0",
+                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multimeter": {
+          "version": "0.1.1",
+          "from": "multimeter@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/multimeter/-/multimeter-0.1.1.tgz",
+          "dependencies": {
+            "charm": {
+              "version": "0.1.2",
+              "from": "charm@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.3.2",
+          "from": "rimraf@>=2.2.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.4.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.4",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "4.3.3",
+          "from": "semver@>=4.2.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.3.tgz"
+        },
+        "yargs": {
+          "version": "3.6.0",
+          "from": "yargs@>=3.2.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.6.0.tgz",
+          "dependencies": {
+            "camelcase": {
+              "version": "1.0.2",
+              "from": "camelcase@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+            },
+            "decamelize": {
+              "version": "1.0.0",
+              "from": "decamelize@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "from": "window-size@0.1.0",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "2.0.2",
-    "ember-cli": "0.2.1",
+    "ember-cli": "0.2.2",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -33,7 +33,7 @@
     "ember-cli-qunit": "0.3.9",
     "ember-cli-sass": "3.1.1",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.16",
+    "ember-data": "1.0.0-beta.16.1",
     "ember-export-application-global": "1.0.2",
     "ember-localstorage-adapter": "kurko/ember-localstorage-adapter#2e4b6f482a09953cf12f774c4242b79c832fce6a",
     "grunt": "^0.4.5",


### PR DESCRIPTION
Actually, all npm versions are now fix. Which isn't exactly ideal for development, so we should revert this right before we actually release.