### PR TITLE
Upgrade nw + ember-cli-node-webkit versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-inline-content": "^0.4.0",
     "ember-cli-materialize": "^0.5.2",
-    "ember-cli-node-webkit": "0.2.0",
+    "ember-cli-node-webkit": "0.2.1",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-sass": "3.3.0",
     "ember-cli-uglify": "1.0.1",
@@ -53,7 +53,7 @@
     "grunt-node-webkit-builder": "^1.0.2",
     "liquid-fire": "ef4/liquid-fire#8fcefd057478ab6852d7b8b3fc8526aa5079553c",
     "load-grunt-tasks": "^1.0.0",
-    "nw": "0.12.0"
+    "nw": "0.12.2"
   },
   "main": "dist/index.html",
   "window": {


### PR DESCRIPTION
 There are issues npm installing the currently specified ones (this *should* get Travis builds to run again too).