### PR TITLE
Refactor Explorer: Extract Upload/Download

### DIFF
--- a/.settings/settings.json
+++ b/.settings/settings.json
@@ -1,0 +1,10 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+	"search.excludeFolders": [
+	    ".git",
+	    "node_modules",
+	    "bower_components",
+	    "dist",
+		"cache"
+	],
+}

--- a/app/controllers/uploaddownload.js
+++ b/app/controllers/uploaddownload.js
@@ -1,0 +1,113 @@
+import Ember from 'ember';
+import Notification from '../models/notification';
+import config from '../config/environment';
+import stringResources from '../utils/string-resources';
+
+export default Ember.Controller.extend({
+    needs: ['notifications', 'explorer'],
+    notifications: Ember.computed.alias('controllers.notifications'),
+    explorer: Ember.computed.alias('controllers.explorer'),
+    nodeServices: Ember.inject.service(),
+
+    actions: {
+	    /**
+        * Upload one or multiple files to blobs
+        * @param  {Array} filePaths  - Local file paths of the files to upload
+        * @param  {string} azurePath - Remote Azure Storage path
+        */
+        uploadBlobData: function (filePaths, azurePath, activeContainer) {
+            var containerPath = azurePath.replace(/.*\:\//, ''),
+                paths = filePaths.split(';'), promises = [];
+
+            this.store.find('container', activeContainer).then(foundContainer => {
+                paths.forEach(path => {
+                    var fileName = path.replace(/^.*[\\\/]/, ''),
+                        uploadNotification, speedSummary, uploadPromise, progressUpdateInterval;
+
+                    var promise = foundContainer.uploadBlob(path, containerPath + fileName).then(result => {
+                        speedSummary = result.speedSummary.summary;
+                        uploadPromise = result.promise;
+
+                        progressUpdateInterval = setInterval(() => {
+                            if (speedSummary) {
+                                // don't report a dead speed. this api reports a speed of 0 for small blobs
+                                var speed = speedSummary.getSpeed() === '0B/S' ? '' : speedSummary.getSpeed();
+
+                                uploadNotification.set('progress', speedSummary.getCompletePercent());
+                                uploadNotification.set('text', stringResources.uploadMessage(fileName, azurePath, speed, speedSummary.getCompletePercent()));
+                            }
+                        }, 200);
+
+                        uploadNotification = Notification.create({
+                            type: 'Upload',
+                            text: stringResources.uploadMessage(fileName, azurePath),
+                            cleanup: function () {
+                                clearInterval(this.get('customData').progressUpdateInterval);
+                            },
+                            customData: {
+                                progressUpdateInterval: progressUpdateInterval
+                            }
+                        });
+
+                        this.get('notifications').addPromiseNotification(result.promise, uploadNotification);
+                        return uploadPromise;
+                    });
+
+                    promises.push(promise);
+                });
+
+                appInsights.trackEvent('uploadBlobData');
+                appInsights.trackMetric('uploadBlobs', paths.length);
+
+                return Ember.RSVP.all(promises);
+            }).then(() => {
+                if (config.environment !== 'test') {
+                    this.get('explorer').send('refreshBlobs');
+                }
+            });
+        },
+
+        /**
+         * Takes an array of blobs and streams them to a target directory
+         * @param  {array} blobs        - Blobs to download
+         * @param  {string} directory   - Local directory to save them to
+         * @param  {boolean} saveAs     - Is the target a directory or a filename (saveAs)?
+         */
+        streamBlobsToDirectory: function (blobs, directory, saveAs) {
+            blobs.forEach(blob => {
+                var fileName = blob.get('name').replace(/^.*[\\\/]/, ''),
+                    targetPath = (saveAs) ? directory : directory + '/' + fileName,
+                    downloadPromise = {isFulfilled : false},
+                    downloadNotification, speedSummary, progressUpdateInterval;
+
+                blob.toFile(targetPath).then(result => {
+                    speedSummary = result.speedSummary.summary;
+                    downloadPromise = result.promise;
+
+                    progressUpdateInterval = setInterval(() => {
+                        if (speedSummary) {
+                            // Don't report a dead speed. This api reports a speed of 0 for small blobs
+                            var speed = speedSummary.getSpeed() === '0B/S' ? '' : speedSummary.getSpeed();
+                            downloadNotification.set('progress', speedSummary.getCompletePercent());
+                            downloadNotification.set('text', stringResources.downloadMessage(blob.get('name'), speed, speedSummary.getCompletePercent()));
+                        }
+                    }, 200);
+
+                    downloadNotification = Notification.create({
+                        type: 'Download',
+                        text: stringResources.downloadMessage(blob.get('name')),
+                        cleanup: function () {
+                            clearInterval(this.get('customData').progressUpdateInterval);
+                        },
+                        customData: {
+                            progressUpdateInterval: progressUpdateInterval
+                        }
+                    });
+
+                    this.get('notifications').addPromiseNotification(downloadPromise, downloadNotification);
+                    return downloadPromise;
+                });
+            });
+        }
+	}
+});

--- a/app/controllers/uploaddownload.js
+++ b/app/controllers/uploaddownload.js
@@ -10,7 +10,7 @@ export default Ember.Controller.extend({
     nodeServices: Ember.inject.service(),
 
     actions: {
-	    /**
+        /**
         * Upload one or multiple files to blobs
         * @param  {Array} filePaths  - Local file paths of the files to upload
         * @param  {string} azurePath - Remote Azure Storage path
@@ -109,5 +109,5 @@ export default Ember.Controller.extend({
                 });
             });
         }
-	}
+    }
 });

--- a/tests/unit/controllers/blob-test.js
+++ b/tests/unit/controllers/blob-test.js
@@ -15,6 +15,6 @@ test('it exists', function (assert) {
             size: 123456
         })
     });
-    console.log(this);
+
     assert.ok(controller);
 });

--- a/tests/unit/controllers/explorer-test.js
+++ b/tests/unit/controllers/explorer-test.js
@@ -9,7 +9,6 @@ var App, store, ns;
 
 function combinedStart(assert) {
     App = startApp(null, assert);
-    ns = App.__container__.lookup('service:nodeServices');
     store = App.__container__.lookup('store:main');
     Ember.run(function () {
         var newAccount = store.createRecord('account', {
@@ -273,19 +272,16 @@ test('it should change subdirectories', function (assert) {
 });
 
 test('it should create a subdirectory/folder upon upload', function (assert) {
-    assert.expect(12);
+    assert.expect(29);
     combinedStart(assert);
 
     var controller = this.subject();
-    var changed = false;
     controller.store = store;
-    
-    controller.set('searchQuery', 'testcontainer');
-    controller.set('activeContainer', 'testcontainer');
 
     controller.addObserver('subDirectories', controller, () => {
-        if (controller.get('subDirectories').length === 3) {
+        if (controller.get('subDirectories').length === 2) {
             controller.get('subDirectories').forEach(subDir => {
+                console.log(subDir);
                 if (subDir.name === 'mydir5/') {
                     assert.ok(true);
                 }
@@ -294,13 +290,17 @@ test('it should create a subdirectory/folder upon upload', function (assert) {
     });
 
     Ember.run(() => {
-        controller.get('containers').then(() => {
-            controller.store.push('blob', {
-                id: 'testcontainersubdir',
-                name: 'mydir5/file.txt'
+        controller.set('searchQuery', 'testcontainer');
+
+        controller.get('containers').then((containers) => {
+            containers.forEach((container) => {
+                if (container.id === 'testcontainer') {
+                    return container.uploadBlob('testpath/file1.jpg', 'mydir5/file1.jpg');
+                }
             });
         }).then(() => {
-            controller.send('refreshBlobs');
+            controller.set('activeContainer', 'testcontainer');
+            controller.send('refreshBlobs');   
         });
     });
 });

--- a/tests/unit/controllers/uploaddownload-test.js
+++ b/tests/unit/controllers/uploaddownload-test.js
@@ -1,0 +1,64 @@
+import Ember from "ember";
+import {
+    moduleFor, test
+}
+from 'ember-qunit';
+import startApp from 'azureexplorer/tests/helpers/start-app';
+
+var App, store;
+
+function combinedStart(assert) {
+    App = startApp(null, assert);
+    store = App.__container__.lookup('store:main');
+    Ember.run(function () {
+        var newAccount = store.createRecord('account', {
+            name: 'Testaccount',
+            key: '5555-5555-5555-5555',
+            active: true
+        });
+    });
+}
+
+moduleFor('controller:uploaddownload', {
+    // Specify the other units that are required for this test.
+    needs: ['controller:application', 'controller:notifications', 'controller:explorer', 'model:blob', 'model:container'],
+    teardown: function () {
+        Ember.run(App, App.destroy);
+        window.localStorage.clear();
+        store = null;
+    }
+});
+
+test('it should upload file to blob', function (assert) {
+    assert.expect(17);
+    combinedStart(assert);
+
+    var controller = this.subject();
+    controller.store = store;
+    
+    Ember.run(() => {
+        store.find('container').then(container => {
+            controller.send('uploadBlobData', '/testdir/testfile.js;/testdir/testfile2.js;/testdir/testfile3.js', 'mydir1/', 'testcontainer');  
+        });
+    });
+});
+
+test('it should download blobs', function (assert) {
+    assert.expect(62);
+    combinedStart(assert);
+
+    var controller = this.subject();
+    controller.store = store;
+
+    Ember.run(function () {
+        store.find('container').then(function (containers) {
+            containers.forEach(function (container) {
+                container.get('blobs', {
+                    prefix: '/'
+                }).then(function (blobs) {
+                    controller.send('streamBlobsToDirectory', blobs, './testdir', true);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
I only extracted the upload/download method, pushing our explorer controller back under 500 lines of code. I could extract more, but then we'd have to deal with way more testing headaches - this way, we have the same tests.