### PR TITLE
Ensure Select isn't cut off

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -58,3 +58,11 @@ body {
 [data-ember-action] {
     cursor: pointer;
 }
+
+// Fix Materialize Select Cut-off issue
+div.card-content, div.card, 
+div.card .liquid-container:not(.liquid-animating),
+div.card .liquid-child:not(.liquid-animating) {
+    overflow: visible!important;
+}
+

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.4.0",
   "description": "A cross-platform tool to explore Azure Storage Accounts",
   "scripts": {
-    "start": "ember server",
-    "build": "ember build",
+    "start": "ember nw",
     "test": "ember build && grunt test && ember nw:test"
   },
   "repository": "",
@@ -53,7 +52,7 @@
     "grunt-jscs": "^0.8.1",
     "grunt-node-webkit-builder": "^1.0.2",
     "grunt-zip": "^0.16.2",
-    "liquid-fire": "ef4/liquid-fire#8fcefd057478ab6852d7b8b3fc8526aa5079553c",
+    "liquid-fire": "^0.19.3",
     "load-grunt-tasks": "^3.2.0",
     "nw": "0.12.2"
   },


### PR DESCRIPTION
Closes #221
- Materialize and Liquid Fire both had `overflow: hidden` on
surrounding elements. This is now overridden.