### PR TITLE
App: Open external protocols

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -41,6 +41,17 @@ export default Ember.Route.extend({
         },
 
         /**
+         * Open a file or a link in the user's preferred app
+         * @param {string} uri
+         * @param {string} application name
+         */
+        open: function () {
+            var nodeOpen = window.requireNode('open');
+
+            nodeOpen(...arguments);
+        },
+
+        /**
          * Enable or disable usage statistics (anonymized)
          */
         toggleUsageStatistics: function (track) {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -42,6 +42,10 @@ body {
     overflow: auto;
 }
 
+a:not(.btn-flat, .btn) {
+    text-decoration: underline;
+}
+
 .visible {
     visibility: visible;
 }

--- a/app/templates/modals/about.hbs
+++ b/app/templates/modals/about.hbs
@@ -2,9 +2,9 @@
     <div class="modal-content">
         <h4>About</h4>
         <p><strong>Azure Storage Explorer v{{versionNumber}}</strong></p>
-        <p>This app is maintained by Steven Edouard and Felix Rieseberg. To report issues, please visit http://aka.ms/ase/issues. </p>
+        <p>This app is maintained by Steven Edouard and Felix Rieseberg. If you find any issues or bugs, <a {{action "open" "https://github.com/azure-storage/xplat/issues/"}}>please let us know</a>!</p>
         <p>(C) Copyright 2015 Microsoft Coporation.</p>
-        <p>The source code for this app is released under the GPLv3 License. For more information, please visit http://azure-storage.github.io/xplat.</p>
+        <p>The source code for this app is released under the GPLv3 License. For more information, please visit <a {{action "open" "http://storageexplorer.com"}}>storageexplorer.com</a>.</p>
     </div>
     <div class="modal-footer">
         <a class="waves-effect waves-green btn-flat modal-action modal-close">Close</a>

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "grunt-zip": "^0.16.2",
     "liquid-fire": "^0.19.3",
     "load-grunt-tasks": "^3.2.0",
-    "nw": "0.12.2"
+    "nw": "0.12.2",
+    "open": "0.0.5"
   },
   "optionalDependencies": {
     "grunt-appdmg": "^0.3.1"


### PR DESCRIPTION
Closes #191
- Calling “open” on the route with a URI will now use the current
user’s default app to open it