### PR TITLE
feat(blobs/properties) - Display & update blob properties

### DIFF
--- a/app/controllers/blob.js
+++ b/app/controllers/blob.js
@@ -1,20 +1,49 @@
 import Ember from 'ember';
 import filesize from '../utils/filesize';
-
+import stringResources from '../utils/string-resources';
+import Notification from '../models/notification';
 /**
  * Controller for the list of blobs, used together with the {{each}} helper
  */
 export default Ember.Controller.extend({
+    needs: ['notifications'],
     /**
      * Returns the filesize in a format that humans can read
-     * @return {[type]} [description]
      */
     prettySize: function () {
         var size = this.get('model.size');
         return filesize(size).human('si');
     }.property('model.size'),
 
+    notifications: Ember.computed.alias('controllers.notifications'),
+
     isLocked: function () {
         return this.get('model.leaseState') !== 'available' || this.get('model.leaseStatus') === 'locked';
-    }.property('model.leaseState', 'model.leaseStatus')
+    }.property('model.leaseState', 'model.leaseStatus'),
+
+    actions: {
+        /**
+         * Save properties for Blob model
+         */
+        setProperties: function () {
+
+            if (this.get('isLocked'))
+            {
+                return;
+            }
+
+            this.get('notifications').addPromiseNotification(this.get('model').save(),
+                Notification.create({
+                    type: 'UpdateBlobProperties',
+                    text: stringResources.updateBlobPropsMessage(this.get('model.name'))
+                })
+            );
+        },
+        /**
+         * Clears unsaved attributes on the Blob model
+         */
+        discardUnsavedChanges: function () {
+            this.get('model').rollback();
+        }
+    }
 });

--- a/app/controllers/explorer.js
+++ b/app/controllers/explorer.js
@@ -509,6 +509,23 @@ export default Ember.Controller.extend({
             }
 
             this.set('blobsSortProperty', [sortProperty]);
-        }
+        },
+
+        /**
+         * Invokes the property modal for the specified model and id.
+         * @param  {string} modelName The name of the model type
+         * @param  {string} id  The ID for the model record to use
+         */
+         invokePropDialog: function (modelName, id) {
+             this.store.find(modelName, id)
+             .then(blob => {
+
+                 if (!blob) {
+                     return;
+                 }
+                 this.send('selectBlob', blob);
+                 this.send('openModal', '#modal-properties', false);
+             });
+         }
     }
 });

--- a/app/models/blob.js
+++ b/app/models/blob.js
@@ -45,6 +45,10 @@ export default DS.Model.extend({
     leaseStatus: DS.attr('string'),         // Lease State (locked/unlocked)
     lastModified: DS.attr('date'),          // Timestamp: Last modified
     container_id: DS.attr('string'),        // ID of the container this blob lives in
+    blobType: DS.attr('string'),            // Blob Type (Page/Block Blob)
+    contentLanguage: DS.attr('string'),     // Content Language
+    contentDisposition: DS.attr('string'),  // Content Disposition
+    contentMd5: DS.attr('string'),          // Content MD5
     type: DS.attr('string'),                // Filetype of the blob (example: image/png)
     selected: DS.attr('boolean'),           // Is this blob selected?
 

--- a/app/routes/explorer.js
+++ b/app/routes/explorer.js
@@ -86,8 +86,11 @@ export default Ember.Route.extend({
          * Opens a specified modal
          * @param  {string} modal jQuery identifier
          */
-        openModal: function (modal) {
-            Ember.$(modal).openModal();
+        openModal: function (modal, dismissible=true) {
+
+            Ember.$(modal).openModal({
+                dismissible: dismissible
+            });
 
             // Ugh: https://github.com/Dogfalo/materialize/issues/1532
             var overlay = Ember.$('.lean-overlay');

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -7,6 +7,7 @@
 @import 'preview';
 @import 'breadcrumbs';
 @import 'notifications';
+@import 'blob-properties';
 
 @font-face {
     font-family: WeblySleek;

--- a/app/styles/blob-properties.scss
+++ b/app/styles/blob-properties.scss
@@ -1,0 +1,22 @@
+#modal-properties {
+    nav.props {
+        background-color: $secondary-color;
+        
+        a.brand-logo {
+            font-size: 20px
+        }
+        
+        tr {
+            margin-top: -10px
+        }
+    }
+    
+    table {
+        margin-left: auto;
+        margin-right: auto;
+        td, th {
+            padding: 0px 0px;
+        }
+    }
+}
+

--- a/app/styles/navbar.scss
+++ b/app/styles/navbar.scss
@@ -1,4 +1,4 @@
-nav {
+nav.explorer {
     background-color: $primary-color-dark;
 }
 

--- a/app/templates/_navbar.hbs
+++ b/app/templates/_navbar.hbs
@@ -1,5 +1,5 @@
 <div class="navbar-fixed">
-    <nav>
+    <nav class="explorer">
         <div class="nav-wrapper">
             <span title="Switch Storage Account" class="logo left" {{action "goHome"}}>
                 {{unbound fa-icon "windows"}}

--- a/app/templates/explorer.hbs
+++ b/app/templates/explorer.hbs
@@ -3,6 +3,7 @@
 {{partial "modals/delete"}}
 {{partial "modals/addcontainer"}}
 {{partial "modals/deletecontainer"}}
+{{render "modals/blob-properties" selectedBlob controller='blob'}}
 
 <div class="explorer-container">
     <div class="folder">
@@ -64,18 +65,18 @@
                         {{/each}}
                         {{#each blob in blobsSorted itemController="blob"}}
                             <tr {{bind-attr class="blob.selected:selected"}}>
-                                <td>
-                                    {{input type="checkbox" id=blob.model.name checked=blob.model.selected}}
-                                    <label for={{blob.model.name}}></label>
+                                <td data-properties-controller="explorer" data-properties-model="blob" data-properties-id="{{blob.model.id}}" data-properties-controller="explorer">
+                                    {{input type="checkbox" id=blob.model.id checked=blob.model.selected}}
+                                    <label for={{blob.model.id}}></label>
                                 </td>
                                 {{#if blob.isLocked}}
-                                    <td {{action "selectBlob" blob.model}}><i class="mdi-action-lock-outline"></i> {{blob-display-path blob.model.name currentPath}}</td>
+                                    <td {{action "selectBlob" blob.model}} data-properties-model="blob" data-properties-id="{{blob.model.id}}" data-properties-controller="explorer"><i class="mdi-action-lock-outline"></i> {{blob-display-path blob.model.id currentPath}}</td>
                                 {{else}}
-                                    <td {{action "selectBlob" blob.model}}>{{blob-display-path blob.model.name currentPath}}</td>
+                                    <td {{action "selectBlob" blob.model}} data-properties-model="blob" data-properties-id="{{blob.model.id}}" data-properties-controller="explorer">{{blob-display-path blob.model.id currentPath}}</td>
                                 {{/if}}
-                                <td {{action "selectBlob" blob.model}} title={{blob.model.lastModified}}>{{ago blob.model.lastModified}}</td>
-                                <td {{action "selectBlob" blob.model}}>{{blob.prettySize}}</td>
-                                <td {{action "selectBlob" blob.model}} class="type" title={{blob.model.type}}>
+                                <td {{action "selectBlob" blob.model}} title={{blob.model.lastModified}} data-properties-model="blob" data-properties-id="{{blob.model.id}}" data-properties-controller="explorer">{{ago blob.model.lastModified}}</td>
+                                <td {{action "selectBlob" blob.model}} data-properties-model="blob" data-properties-id="{{blob.model.id}}" data-properties-controller="explorer">{{blob.prettySize}}</td>
+                                <td {{action "selectBlob" blob.model}} class="type" title={{blob.model.type}} data-properties-model="blob" data-properties-id="{{blob.model.id}}" data-properties-controller="explorer">
                                     <div>{{blob.model.type}}</div>
                                 </td>
                             </tr>

--- a/app/templates/modals/blob-properties.hbs
+++ b/app/templates/modals/blob-properties.hbs
@@ -1,0 +1,72 @@
+<div id="modal-properties" class="modal" >
+    <nav class="props">
+        <div class="nav-wrapper">
+            <a class="brand-logo right">Properties</a>
+        </div>
+    </nav>
+    <div class="modal-content">
+        <table class="striped properties">
+            <thead>
+                
+            </thead>
+            <tr>
+                <th>Name:</th>
+                <th>{{model.name}}</th>
+            </tr>
+            <tr>
+                <th>Last Modified:</th>
+                <th>{{model.lastModified}}</th>
+            </tr>
+            <tr>
+                <td >Size (bytes):</td>
+                <td >{{model.size}}</td>
+            </tr>
+            <tr>
+                <td >Blob Type:</td>
+                <td>{{model.blobType}}</td>
+            </tr>
+            <tr>
+                <td >Lease Status:</td>
+                <td >{{model.leaseStatus}}</td>
+            </tr>
+            <tr>
+                <td >Lease State:</td>
+                <td>{{model.leaseState}}</td>
+            </tr>
+            {{#if model.leaseID}}
+                <tr>
+                    <td >Lease State:</td>
+                    <td>{{model.leaseState}}</td>
+                </tr>
+            {{/if}}
+            {{#if model.etag}}
+                <tr>
+                    <td >ETag:</td>
+                    <td>{{model.etag}}</td>
+                </tr>
+            {{/if}}
+            <tr>
+                <td >Content MD5:</td>
+                <td>{{input value=model.contentMd5 disabled=isLocked}}</td>
+            </tr>
+            <tr>
+                <td >Content Language:</td>
+                <td>{{input value=model.contentLanguage disabled=isLocked}}</td>
+            </tr>
+            <tr>
+                <td >Content Disposition:</td>
+                <td>{{input value=model.contentDisposition disabled=isLocked}}</td>
+            </tr>
+        </table>
+    </div>
+    <div class="modal-footer">
+        <a {{action "discardUnsavedChanges"}} class=" modal-action modal-close waves-effect waves-green btn-flat">Close</a>
+        {{#if isLocked}}
+        {{else}}
+            <a {{action "setProperties"}} class=" modal-action modal-close waves-effect waves-green btn-flat">Update</a>
+        {{/if}}
+    </div>
+    <!--<div class="modal-footer">
+        <a {{action 'uploadBlobData' modalFileUploadPath modalDefaultUploadPath}} class=" modal-action modal-close waves-effect waves-green btn-flat">Upload</a>
+    </div>-->
+</div>

--- a/app/utils/context-menu.js
+++ b/app/utils/context-menu.js
@@ -55,11 +55,38 @@ function Menu() {
 }
 
 var contextMenu = {
-    setup: function () {
-        var menu = new Menu();
+    /**
+     * Changes the sorting of the blobs, using a given property
+     */
+    _setup_property_menu: function (e, menu) {
+        var element = document.elementFromPoint(e.originalEvent.x, e.originalEvent.y),
+                id = element.getAttribute('data-properties-id'),
+                propModel = element.getAttribute('data-properties-model'),
+                controllerName = element.getAttribute('data-properties-controller');
 
-        Ember.$(document).on('contextmenu', function (e) {
+        if (id && propModel && controllerName) {
+            var gui = window.requireNode('nw.gui');
+            menu.append(new gui.MenuItem({
+                label: 'Properties',
+                click: function () {
+                    var controller = window.Azureexplorer.__container__.lookup('controller:' + controllerName);
+
+                    if (controller) {
+                        controller.send('invokePropDialog', propModel, id);
+                    }
+                }
+            }));
+        }
+    },
+
+    /**
+     * Listens to the contextmenu event to provide a customized context menu
+     */
+    setup: function () {
+        Ember.$(document).on('contextmenu', (e) => {
             e.preventDefault();
+            var menu = new Menu();
+            this._setup_property_menu(e, menu);
             menu.popup(e.originalEvent.x, e.originalEvent.y);
         });
     }

--- a/app/utils/string-resources.js
+++ b/app/utils/string-resources.js
@@ -37,5 +37,8 @@ export default {
     },
     deleteContainerMessage: function (containerName) {
         return 'Deleting Container ' + containerName;
+    },
+    updateBlobPropsMessage: function (blobName) {
+        return 'Updating Blob Properties for ' + blobName;
     }
 };

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -307,6 +307,10 @@ export default function startApp(attrs, assert, noNodeServices) {
                     return callback(null);
                 },
                 
+                setBlobProperties: function (containerName, blobName, properties, callback) {
+                    return callback();
+                },
+                
                 BlobUtilities: {
                     SharedAccessPermissions: {
                         READ: 'READ'

--- a/tests/unit/controllers/blob-test.js
+++ b/tests/unit/controllers/blob-test.js
@@ -9,7 +9,7 @@ import startApp from 'azureexplorer/tests/helpers/start-app';
 var App, store, ns;
 
 moduleFor('controller:blob', {
-    needs: ['util:filesize', 'model:container', 'model:blob']
+    needs: ['util:filesize', 'model:container', 'model:blob', 'controller:notifications']
 });
 
 function combinedStart(assert) {
@@ -27,7 +27,6 @@ function combinedStart(assert) {
 function getBlobs() {
    return store.find('container')
     .then(function (containers) {
-        console.log('running!');
         let retContainer = null;
         containers.every(container => {
             retContainer = container;
@@ -45,7 +44,6 @@ test('it calculates pretty size', function (assert) {
     Ember.run(() => {
         getBlobs()
         .then(blobs => {
-            console.log(blobs);
             blobs.forEach(blob => {
                 blob.set('size', 12313435);
 
@@ -66,15 +64,15 @@ test('it calculates lock status correctly (locked)', function (assert) {
     Ember.run(() => {
         store.find('container')
         .then(function (containers) {
-            console.log('running!');
+
             containers.forEach(container => {
                 container.get('blobs')
                 .then(blobs => {
-                    console.log(blobs);
+
                     blobs.every(blob => {
                         blob.set('leaseStatus', 'locked');
                         blob.set('leaseState', 'unavailable');
-                        console.log('hello!');
+
                         let controller = self.subject({
                             model: blob
                         });
@@ -97,6 +95,7 @@ test('it calculates lock status correctly (unlocked)', function (assert) {
         getBlobs()
         .then(blobs => {
             blobs.every(blob => {
+
                 blob.set('leaseStatus', 'unlocked');
                 blob.set('leaseState', 'available');
 
@@ -106,6 +105,96 @@ test('it calculates lock status correctly (unlocked)', function (assert) {
 
                 assert.equal(controller.get('isLocked'), false);
                 
+                return false;
+            });
+        }); 
+    });
+});
+
+test('it updates blob properties', function (assert) {
+    combinedStart(assert);
+    var self = this;
+    assert.expect(11);
+    Ember.run(() => {
+        getBlobs()
+        .then(blobs => {
+            blobs.every(blob => {
+                blob.set('contentLanguage', 'English');
+                blob.set('contentDisposition', 'attachment');
+                blob.set('leaseState', 'available');
+                blob.set('leaseStatus', 'unlocked');
+                let controller = self.subject({
+                    model: blob
+                });
+
+                controller.get('notifications').addPromiseNotification = function (promise) {
+                        
+                    promise.then(() => {
+                        assert.equal(controller.get('model.isDirty'), false);
+                        assert.equal(controller.get('model.contentLanguage'), 'English');
+                        assert.equal(controller.get('model.contentDisposition'), 'attachment');
+                    });
+                        
+                };
+                
+                controller.send('setProperties');
+
+                return false;
+            });
+        }); 
+    });
+});
+
+test('it does not update blob properties', function (assert) {
+    combinedStart(assert);
+    var self = this;
+    assert.expect(9);
+    Ember.run(() => {
+        getBlobs()
+        .then(blobs => {
+            blobs.every(blob => {
+                blob.set('contentLanguage', 'English');
+                blob.set('contentDisposition', 'attachment');
+                blob.set('leaseState', 'available');
+                blob.set('leaseStatus', 'unlocked');
+                let controller = self.subject({
+                    model: blob
+                });
+
+                controller.get('notifications').addObserver('notifications', () => {
+                    assert(false, 'did not expect to see any attributes change');
+                });
+                controller.send('discardUnsavedChanges');
+                
+                assert.equal(controller.get('model.isDirty'), false);
+                return false;
+            });
+        }); 
+    });
+});
+
+test('it does not update a locked blob', function (assert) {
+    combinedStart(assert);
+    var self = this;
+    assert.expect(9);
+    Ember.run(() => {
+        getBlobs()
+        .then(blobs => {
+            blobs.every(blob => {
+                blob.set('contentLanguage', 'English');
+                blob.set('contentDisposition', 'attachment');
+                blob.set('leaseState', 'unavailable');
+                blob.set('leaseStatus', 'locked');
+                let controller = self.subject({
+                    model: blob
+                });
+
+                controller.get('notifications').addObserver('notifications', () => {
+                    assert(false, 'did not expect to see any attributes change');
+                });
+                controller.send('setProperties');
+                
+                assert.equal(controller.get('model.isDirty'), true);
                 return false;
             });
         }); 


### PR DESCRIPTION
Right click Select Properties:
![screen shot 2015-07-28 at 5 56 16 pm](https://cloud.githubusercontent.com/assets/3053263/8947637/17391f22-3552-11e5-9eae-5bf382cb47ed.png)

If blob is locked you can't edit it:
![screen shot 2015-07-28 at 6 03 11 pm](https://cloud.githubusercontent.com/assets/3053263/8947958/4556679e-3556-11e5-8fa3-792c7b6a1c06.png)

And if it isn't, you can:

![screen shot 2015-07-28 at 5 56 48 pm](https://cloud.githubusercontent.com/assets/3053263/8947966/59c5ea4c-3556-11e5-9ab6-e98afaae98b5.png)

![screen shot 2015-07-28 at 6 35 43 pm](https://cloud.githubusercontent.com/assets/3053263/8948051/7f761e14-3557-11e5-9936-36ba20500bcd.png)


In the future we can add tabs on the navbar for Metadata and a PageBlob browser.