### PR TITLE
Bump nw version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
   "dependencies": {
     "azure-storage": "^0.4.3",
     "open": "0.0.5",
-    "nw": "0.12.2"
+    "nw": "0.12.3"
   }
 }


### PR DESCRIPTION
- Support Mac App Store with the 'macappstore' flavor
- [HighDPI][WIN] Fix for tray menu is huge on High-DPI Windows machine