### PR TITLE
Upgrade to grunt-nw-builder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,26 +63,29 @@ module.exports = function (grunt) {
         // Execute individual builds with the commands below
         // Warning: If trying to compile Windows with Icon 
         // on OS X / Linux, you'll need Wine.
-        nodewebkit: {
+        nwjs: {
             osx: {
                 options: {
                     platforms: ['osx64'],
                     buildDir: './webkitbuilds',
                     macIcns: './public/icon/ase.icns',
+                    version: 'v0.12.3'
                 },
                 src: ['./nwbuildcache/**/*']
             },
             linux: {
                 options: {
                     platforms: ['linux64'],
-                    buildDir: './webkitbuilds'
+                    buildDir: './webkitbuilds',
+                    version: 'v0.12.3'
                 },
                 src: ['./nwbuildcache/**/*']
             },
             windows: {
                 options: {
                     platforms: ['win32'],
-                    buildDir: './webkitbuilds'
+                    buildDir: './webkitbuilds',
+                    version: 'v0.12.3'
                 },
                 src: ['./nwbuildcache/**/*']
             },
@@ -90,7 +93,8 @@ module.exports = function (grunt) {
                 options: {
                     platforms: ['win32'],
                     buildDir: './webkitbuilds',
-                    winIco: './public/icon/ase.ico'
+                    winIco: './public/icon/ase.ico',
+                    version: 'v0.12.3'
                 },
                 src: ['./nwbuildcache/**/*']
             }
@@ -263,15 +267,15 @@ module.exports = function (grunt) {
     grunt.registerTask('beautify', ['js_beautify']);
     grunt.registerTask('copyForBuild', ['copy:nwbuildcache', 'copy:azure_storage', 'copy:memorystream', 'copy:open', 'copy:pack', 'copy:version_file']);
     grunt.registerTask('prebuild', ['clean', 'exec:build', 'file-creator:version_file', 'copyForBuild']);
-    grunt.registerTask('compileOSX', ['nodewebkit:osx', 'copy:bin_osx', 'appdmg', 'exec:dmgLicense']);
-    grunt.registerTask('compileLinux', ['nodewebkit:linux', 'copy:bin_linux', 'copy:license_linux']);
-    grunt.registerTask('compileWindows', ['nodewebkit:windows', 'copy:bin_windows', 'copy:license_windows']);
-    grunt.registerTask('compileWindowsWithIcon', ['nodewebkit:windowsWithIcon', 'copy:bin_windows']);
+    grunt.registerTask('compileOSX', ['nwjs:osx', 'copy:bin_osx', 'appdmg', 'exec:dmgLicense']);
+    grunt.registerTask('compileLinux', ['nwjs:linux', 'copy:bin_linux', 'copy:license_linux']);
+    grunt.registerTask('compileWindows', ['nwjs:windows', 'copy:bin_windows', 'copy:license_windows']);
+    grunt.registerTask('compileWindowsWithIcon', ['nwjs:windowsWithIcon', 'copy:bin_windows']);
     grunt.registerTask('compile', ['prebuild', 'compileOSX', 'compileWindows', 'compileLinux']);
 
     // Development Builds
     // To deploy a build with an official build number, set env var RELEASE_VERSION to release number
     // otherwise application is tagged with git hash
-    grunt.registerTask('compileDevBuild', ['prebuild', 'nodewebkit:osx', 'copy:bin_osx', 'nodewebkit:windows', 'copy:bin_windows', 'nodewebkit:linux', 'copy:bin_linux', 'copy:license_windows', 'copy:license_osx', 'copy:license_linux']);
+    grunt.registerTask('compileDevBuild', ['prebuild', 'nwjs:osx', 'copy:bin_osx', 'nwjs:windows', 'copy:bin_windows', 'nwjs:linux', 'copy:bin_linux', 'copy:license_windows', 'copy:license_osx', 'copy:license_linux']);
     grunt.registerTask('createDevBuild', ['compileDevBuild', 'zip', 'if:trusted-deploy-to-azure-cdn']);
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "email": "sedouard@microsoft.com"
     }
   ],
-  "license": "GPL",
+  "license": "GPL-3.0+",
   "devDependencies": {
     "broccoli-asset-rev": "2.0.2",
     "broccoli-funnel": "^0.2.3",
@@ -69,7 +69,7 @@
     "grunt-js-beautify": "^0.1.1",
     "grunt-jscodesniffer": "^0.1.8",
     "grunt-jscs": "^0.8.1",
-    "grunt-node-webkit-builder": "^1.0.2",
+    "grunt-nw-builder": "^2.0.0",
     "grunt-zip": "^0.16.2",
     "liquid-fire": "0.21.0",
     "load-grunt-tasks": "^3.2.0",
@@ -94,6 +94,7 @@
   "dependencies": {
     "azure-storage": "^0.4.3",
     "fs-extra": "^0.22.1",
+    "grunt-nw-builder": "^2.0.0",
     "nw": "0.12.3",
     "open": "0.0.5"
   }


### PR DESCRIPTION
Upgrades `grunt-node-webkit-builder` to `grunt-nw-builder` and locks the nw.js version, therefore fixing our builds.

Closes #286 