### PR TITLE
Travis: Create Dev Build in Deploy Phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,10 @@ install:
 script:
   - xvfb-run ember nw:test
   - grunt test
-  - grunt createDevBuild
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: postcompile/deploy.sh
+  on:
+    branch: master

--- a/postcompile/deploy.sh
+++ b/postcompile/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grunt createDevBuild


### PR DESCRIPTION
Previously, we created a dev build whenever a test finished. This change makes use of the Travis `deploy` phase, allowing us to deploy only on `master` (and not in PRs, etc). This also enables us to test PRs correctly - meaning that a failed build won't block greenlit code.

Closes #290 